### PR TITLE
New plugin: next-graphql

### DIFF
--- a/packages/next-graphql/index.js
+++ b/packages/next-graphql/index.js
@@ -9,7 +9,6 @@ module.exports = (nextConfig = {}) => {
 
       const { dir } = options
 
-      config.resolve.extensions.push('.ts', '.tsx')
       config.module.rules.push({
         test: /\.(graphql|gql)$/,
         include: [dir],

--- a/packages/next-graphql/index.js
+++ b/packages/next-graphql/index.js
@@ -1,0 +1,31 @@
+module.exports = (nextConfig = {}) => {
+  return Object.assign({}, nextConfig, {
+    webpack(config, options) {
+      if (!options.defaultLoaders) {
+        throw new Error(
+          'This plugin is not compatible with Next.js versions below 5.0.0 https://err.sh/next-plugins/upgrade'
+        )
+      }
+
+      const { dir } = options
+
+      config.resolve.extensions.push('.ts', '.tsx')
+      config.module.rules.push({
+        test: /\.(graphql|gql)$/,
+        include: [dir],
+        exclude: /node_modules/,
+        use: [
+          {
+            loader: 'graphql-tag/loader'
+          }
+        ]
+      })
+
+      if (typeof nextConfig.webpack === 'function') {
+        return nextConfig.webpack(config, options)
+      }
+
+      return config
+    }
+  })
+}

--- a/packages/next-graphql/package.json
+++ b/packages/next-graphql/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@zeit/next-graphql",
+  "version": "0.0.1",
+  "main": "index.js",
+  "license": "MIT",
+  "repository": "zeit/next-plugins",
+  "dependencies": {
+    "graphql-tag": "^2.6.1"
+  }
+}

--- a/packages/next-graphql/readme.md
+++ b/packages/next-graphql/readme.md
@@ -1,0 +1,37 @@
+# Next.js + Typescript
+
+Use [Graphql](http://graphql.org/) files with [Next.js](https://github.com/zeit/next.js)
+
+## Installation
+
+```sh
+npm install --save @zeit/next-graphql
+```
+
+or
+
+```sh
+yarn add @zeit/next-graphql
+```
+
+## Usage
+
+Create a `next.config.js` in your project
+
+```js
+// next.config.js
+const withGraphql = require('@zeit/next-graphql')
+module.exports = withGraphql()
+```
+
+Optionally you can add your custom Next.js configuration as parameter
+
+```js
+// next.config.js
+const withGraphql = require('@zeit/next-graphql')
+module.exports = withGraphql({
+  webpack(config, options) {
+    return config
+  }
+})
+```

--- a/packages/next-graphql/readme.md
+++ b/packages/next-graphql/readme.md
@@ -1,4 +1,4 @@
-# Next.js + Typescript
+# Next.js + Graphql
 
 Use [Graphql](http://graphql.org/) files with [Next.js](https://github.com/zeit/next.js)
 


### PR DESCRIPTION
Adds support for `.gql` and `.graphql` files using the loader included in [graphql-tag](https://github.com/apollographql/graphql-tag#webpack-preprocessing-with-graphql-tagloader)