### PR TITLE
remove importLoaders option

### DIFF
--- a/packages/next-css/css-loader-config.js
+++ b/packages/next-css/css-loader-config.js
@@ -47,8 +47,7 @@ module.exports = (
     fallback: {
       loader: 'style-loader',
       options: {
-        sourceMap: dev,
-        importLoaders: 1
+        sourceMap: dev
       }
     }
   })


### PR DESCRIPTION
It remove importLoaders option

Because seen with @timneutkens on slack https://zeit-community.slack.com/archives/C2U01UYEA/p1517924016000497