### PR TITLE
next-{css,less,sass}: fix README examples

### DIFF
--- a/packages/next-css/readme.md
+++ b/packages/next-css/readme.md
@@ -79,7 +79,7 @@ import Head from 'next/head'
 export default () => {
   return <div>
     <Head>
-      <link rel="stylesheet" href="/_next/static/style.css">
+      <link rel="stylesheet" href="/_next/static/style.css" />
     </Head>
   </div>
 }
@@ -94,7 +94,7 @@ export default class MyDocument extends Document {
     return (
       <html>
         <Head>
-          <link rel="stylesheet" href="/_next/static/style.css">
+          <link rel="stylesheet" href="/_next/static/style.css" />
         </Head>
         <body>
           <Main />

--- a/packages/next-css/readme.md
+++ b/packages/next-css/readme.md
@@ -26,7 +26,7 @@ const withCSS = require('@zeit/next-css')
 module.exports = withCSS()
 ```
 
-Create a CSS file `styles.css`
+Create a CSS file `style.css`
 
 ```css
 .example {
@@ -37,7 +37,7 @@ Create a CSS file `styles.css`
 Create a page file `pages/index.js`
 
 ```js
-import "../styles.css"
+import "../style.css"
 
 export default () => <div className="example">Hello World!</div>
 ```
@@ -52,7 +52,7 @@ module.exports = withCSS({
 })
 ```
 
-Create a CSS file `styles.css`
+Create a CSS file `style.css`
 
 ```css
 .example {
@@ -63,7 +63,7 @@ Create a CSS file `styles.css`
 Create a page file `pages/index.js`
 
 ```js
-import css from "../styles.css"
+import css from "../style.css"
 
 export default () => <div className={css.example}>Hello World!</div>
 ```
@@ -128,7 +128,7 @@ module.exports = {
 }
 ```
 
-Create a CSS file `styles.css` the CSS here is using the css-variables postcss plugin.
+Create a CSS file `style.css` the CSS here is using the css-variables postcss plugin.
 
 ```css
 :root {

--- a/packages/next-less/readme.md
+++ b/packages/next-less/readme.md
@@ -81,7 +81,7 @@ import Head from 'next/head'
 export default () => {
   return <div>
     <Head>
-      <link rel="stylesheet" href="/_next/static/style.css">
+      <link rel="stylesheet" href="/_next/static/style.css" />
     </Head>
   </div>
 }
@@ -96,7 +96,7 @@ export default class MyDocument extends Document {
     return (
       <html>
         <Head>
-          <link rel="stylesheet" href="/_next/static/style.css">
+          <link rel="stylesheet" href="/_next/static/style.css" />
         </Head>
         <body>
           <Main />

--- a/packages/next-sass/readme.md
+++ b/packages/next-sass/readme.md
@@ -81,7 +81,7 @@ import Head from 'next/head'
 export default () => {
   return <div>
     <Head>
-      <link rel="stylesheet" href="/_next/static/style.css">
+      <link rel="stylesheet" href="/_next/static/style.css" />
     </Head>
   </div>
 }
@@ -96,7 +96,7 @@ export default class MyDocument extends Document {
     return (
       <html>
         <Head>
-          <link rel="stylesheet" href="/_next/static/style.css">
+          <link rel="stylesheet" href="/_next/static/style.css" />
         </Head>
         <body>
           <Main />


### PR DESCRIPTION
The `<link ...>` tags need to be self-closing.