### PR TITLE
Add server rendering support

### DIFF
--- a/packages/next-css/babel.js
+++ b/packages/next-css/babel.js
@@ -1,0 +1,152 @@
+/* eslint-disable new-cap */
+const STYLE_COMPONENT = '_NextCSS'
+const STYLE_MODULE = '@zeit/next-css/inline-style'
+
+module.exports = function({ types: t }) {
+  return {
+    visitor: {
+      Program: {
+        enter(path, state) {
+          if (!state.opts.pattern) {
+            state.opts.pattern = /\.css$/
+          }
+          if (typeof state.opts.pattern === 'string') {
+            state.opts.pattern = new RegExp(state.opts.pattern)
+          }
+          state.imports = []
+          state.isStyleModuleImported = false
+        },
+        exit({ node, scope }, state) {
+          if (
+            state.imports.length === 0 ||
+            scope.hasBinding(STYLE_COMPONENT) ||
+            state.isStyleModuleImported
+          ) {
+            return
+          }
+
+          node.body.unshift(
+            t.importDeclaration(
+              [t.importDefaultSpecifier(t.identifier(STYLE_COMPONENT))],
+              t.stringLiteral(STYLE_MODULE)
+            )
+          )
+        }
+      },
+      ImportDeclaration(path, state) {
+        const source = path.get('source').node.value
+        if (source === STYLE_MODULE) {
+          state.isStyleModuleImported = true
+        } else if (state.opts.pattern.test(source)) {
+          const specifiers = path.get('specifiers')
+          if (specifiers.length === 0) {
+            path.replaceWith(
+              t.importDeclaration(
+                [
+                  t.importDefaultSpecifier(
+                    path.scope.generateUidIdentifier('globalStyles')
+                  )
+                ],
+                t.stringLiteral(source)
+              )
+            )
+            return
+          }
+          for (const specifier of specifiers) {
+            if (t.isImportDefaultSpecifier(specifier)) {
+              state.imports.push(specifier.get('local').node.name)
+              return
+            }
+          }
+
+          const id = path.scope.generateUidIdentifier('css')
+          path.replaceWith(
+            t.importDeclaration(
+              [t.importDefaultSpecifier(id), ...path.node.specifiers],
+              t.stringLiteral(source)
+            )
+          )
+        }
+      },
+      CallExpression(path, state) {
+        if (
+          path.get('callee').node.name !== 'require' ||
+          t.isVariableDeclarator(path.parent)
+        ) {
+          return
+        }
+        const source = path.get('arguments')[0].node.value
+        if (state.opts.pattern.test(source)) {
+          path.parentPath.replaceWith(
+            t.variableDeclaration('var', [
+              t.variableDeclarator(
+                path.scope.generateUidIdentifier('globalStyles'),
+                t.callExpression(t.identifier('require'), [
+                  t.stringLiteral(source)
+                ])
+              )
+            ])
+          )
+        }
+      },
+      VariableDeclarator(path, state) {
+        const subpath = path.get('init')
+        if (
+          !subpath.isCallExpression() ||
+          subpath.get('callee').node.name !== 'require'
+        ) {
+          return
+        }
+        const source = subpath.get('arguments')[0].node.value
+        if (source === STYLE_MODULE) {
+          state.isStyleModuleImported = true
+        } else if (state.opts.pattern.test(source)) {
+          state.imports.push(path.get('id').node.name)
+        }
+      },
+      JSXElement(path, state) {
+        if (
+          state.imports.length === 0 ||
+          t.isJSXElement(path.parent) ||
+          path.get('openingElement').node.name.name === STYLE_COMPONENT ||
+          state.isStyleModuleImported
+        ) {
+          return
+        }
+        const openingNode = path.get('openingElement').node
+        const hoistProps = []
+        const ownProps = openingNode.attributes.reduce((props, prop) => {
+          if (
+            t.isJSXAttribute(prop) &&
+            ['key'].indexOf(prop.name.name) !== -1
+          ) {
+            hoistProps.push(prop)
+          } else {
+            props.push(prop)
+          }
+          return props
+        }, [])
+        openingNode.attributes = ownProps
+
+        path.replaceWith(
+          t.jSXElement(
+            t.jSXOpeningElement(t.jSXIdentifier(STYLE_COMPONENT), [
+              ...hoistProps,
+              t.jSXAttribute(
+                t.jSXIdentifier('css'),
+                t.jSXExpressionContainer(
+                  t.arrayExpression(
+                    state.imports.map(importId => t.Identifier(importId))
+                  )
+                )
+              )
+            ]),
+            t.jSXClosingElement(t.jSXIdentifier(STYLE_COMPONENT)),
+            [t.jSXText('\n'), path.node, t.jSXText('\n')],
+            false
+          )
+        )
+      }
+    }
+  }
+}

--- a/packages/next-css/css-loader-config.js
+++ b/packages/next-css/css-loader-config.js
@@ -1,7 +1,6 @@
-const findUp = require('find-up')
-
 function getPostCssLoader(cwd) {
-  const postcssConfig = findUp.sync('postcss.config.js', {
+  // We require inside the function to not load at startup
+  const postcssConfig = require('find-up').sync('postcss.config.js', {
     cwd
   })
 

--- a/packages/next-css/css-loader-config.js
+++ b/packages/next-css/css-loader-config.js
@@ -1,27 +1,12 @@
 const findUp = require('find-up')
 
-module.exports = (
-  config,
-  extractPlugin,
-  { cssModules = false, dev, isServer, loaders = [] }
-) => {
-  const cssLoader = {
-    loader: isServer ? 'css-loader/locals' : 'css-loader',
-    options: {
-      modules: cssModules,
-      minimize: !dev,
-      sourceMap: dev,
-      importLoaders: 1
-    }
-  }
-
+function getPostCssLoader(cwd) {
   const postcssConfig = findUp.sync('postcss.config.js', {
-    cwd: config.context
+    cwd
   })
-  let postcssLoader
 
   if (postcssConfig) {
-    postcssLoader = {
+    return {
       loader: 'postcss-loader',
       options: {
         config: {
@@ -31,25 +16,68 @@ module.exports = (
     }
   }
 
+  return false
+}
+
+module.exports = (
+  config,
+  extractPlugin,
+  { cssToString = false, cssModules = false, dev, isServer, loaders = [] }
+) => {
   // When not using css modules we don't transpile on the server
-  if (isServer && !cssLoader.options.modules) {
+  if (isServer && !cssToString && !cssModules) {
     return ['ignore-loader']
+  }
+
+  config.externals = config.externals.map(external => {
+    if (typeof external === 'function') {
+      return (context, request, callback) => {
+        if (request.match(/node_modules[/\\]css-loader/)) {
+          return callback()
+        }
+
+        return external(context, request, callback)
+      }
+    }
+    return external
+  })
+
+  const postcssLoader = getPostCssLoader(config.context)
+
+  const cssLoader = {
+    loader: !cssToString && isServer ? 'css-loader/locals' : 'css-loader',
+    options: {
+      modules: cssModules,
+      minimize: !dev,
+      sourceMap: dev,
+      importLoaders: loaders.length + (postcssLoader ? 1 : 0)
+    }
+  }
+
+  const appliedLoaders = [cssLoader, postcssLoader, ...loaders].filter(Boolean)
+
+  // When using css.toString() we apply the loaders in dev + production and don't extract the css.
+  // Because it's server rendered.
+  if (cssToString) {
+    return appliedLoaders
   }
 
   // When on the server and using css modules we transpile the css
   if (isServer && cssLoader.options.modules) {
-    return [cssLoader, postcssLoader, ...loaders].filter(Boolean)
+    return appliedLoaders
   }
 
-  return extractPlugin.extract({
-    use: [cssLoader, postcssLoader, ...loaders].filter(Boolean),
-    // Use style-loader in development
-    fallback: {
-      loader: 'style-loader',
-      options: {
-        sourceMap: dev,
-        importLoaders: 1
-      }
+  const extractTextOptions = {
+    use: appliedLoaders
+  }
+
+  // Use style-loader in development in the client bundle
+  extractTextOptions.fallback = {
+    loader: 'style-loader',
+    options: {
+      sourceMap: dev
     }
-  })
+  }
+
+  return extractPlugin.extract(extractTextOptions)
 }

--- a/packages/next-css/index.js
+++ b/packages/next-css/index.js
@@ -1,6 +1,3 @@
-const ExtractTextPlugin = require('extract-text-webpack-plugin')
-const cssLoaderConfig = require('./css-loader-config')
-
 module.exports = (nextConfig = {}) => {
   return Object.assign({}, nextConfig, {
     webpack(config, options) {
@@ -11,7 +8,7 @@ module.exports = (nextConfig = {}) => {
       }
 
       const { dev, isServer } = options
-      const { cssModules } = nextConfig
+      const { cssModules, cssToString } = nextConfig
       // Support the user providing their own instance of ExtractTextPlugin.
       // If extractCSSPlugin is not defined we pass the same instance of ExtractTextPlugin to all css related modules
       // So that they compile to the same file in production
@@ -19,6 +16,7 @@ module.exports = (nextConfig = {}) => {
         nextConfig.extractCSSPlugin || options.extractCSSPlugin
 
       if (!extractCSSPlugin) {
+        const ExtractTextPlugin = require('extract-text-webpack-plugin')
         extractCSSPlugin = new ExtractTextPlugin({
           filename: 'static/style.css'
         })
@@ -30,7 +28,9 @@ module.exports = (nextConfig = {}) => {
         extractCSSPlugin.options.disable = dev
       }
 
+      const cssLoaderConfig = require('./css-loader-config')
       options.defaultLoaders.css = cssLoaderConfig(config, extractCSSPlugin, {
+        cssToString,
         cssModules,
         dev,
         isServer

--- a/packages/next-css/inline-style.js
+++ b/packages/next-css/inline-style.js
@@ -1,0 +1,16 @@
+/* eslint-disable import/no-extraneous-dependencies, no-unused-vars, import/no-unresolved, */
+import { Fragment } from 'react'
+import Head from 'next/head'
+
+export default ({ css, children }) => {
+  return (
+    <Fragment>
+      {children}
+      {css.map((single, index) => (
+        <Head key={index}>
+          <style>{single.toString()}</style>
+        </Head>
+      ))}
+    </Fragment>
+  )
+}

--- a/packages/next-css/readme.md
+++ b/packages/next-css/readme.md
@@ -68,6 +68,40 @@ import css from "../styles.css"
 export default () => <div className={css.example}>Hello World!</div>
 ```
 
+### Server rendering / styled-jsx like behavior
+
+```js
+// next.config.js
+const withCSS = require('@zeit/next-css')
+module.exports = withCSS({
+  cssModules: true,
+  cssToString: true
+})
+```
+
+Create a CSS file `styles.css`
+
+```css
+.example {
+  font-size: 50px;
+}
+```
+
+Create a page file `pages/index.js`
+
+```
+import Head from 'next/head'
+import css from '../style.css'
+
+export default () => <div className={css.locals.example}>
+  Hello World!
+  <Head>
+    <style>{css.toString()}</style>
+  </Head>
+</div>
+
+```
+
 ### Production usage
 
 In production the stylesheet is compiled to `.next/static/style.css`. You have to include it into the page using either [`next/head`](https://github.com/zeit/next.js#populating-head) or a custom [`_document.js`](https://github.com/zeit/next.js#custom-document). The file will be served from `/_next/static/style.css`

--- a/packages/next-css/readme.md
+++ b/packages/next-css/readme.md
@@ -89,7 +89,7 @@ Create a CSS file `styles.css`
 
 Create a page file `pages/index.js`
 
-```
+```js
 import Head from 'next/head'
 import css from '../style.css'
 


### PR DESCRIPTION
Adds a new option, `cssToString` which enables full transpilation on the server and disables extractTextPlugin. Automatically adds support for this in next-less and next-sass too 🙏 

```js
// next.config.js
const withCSS = require('@zeit/next-css')
module.exports = withCSS({
  cssModules: true,
  cssToString: true
})
```

Create a CSS file `styles.css`

```css
.example {
  font-size: 50px;
}
```

Create a page file `pages/index.js`

```js
import Head from 'next/head'
import css from '../style.css'

export default () => <div className={css.locals.example}>
  Hello World!
  <Head>
    <style>{css.toString()}</style>
  </Head>
</div>

```