### PR TITLE
Allow next-css to accept css-loader options

### DIFF
--- a/packages/next-css/css-loader-config.js
+++ b/packages/next-css/css-loader-config.js
@@ -5,15 +5,25 @@ module.exports = (
   extractPlugin,
   { cssModules = false, dev, isServer, loaders = [] }
 ) => {
+  const defaultOptions = {
+    minimize: !dev,
+    sourceMap: dev,
+    importLoaders: 1,
+    modules: cssModules,
+  };
+
+  let options = defaultOptions;
+  if (typeof cssModules === "object") {
+    options = {
+      ...options,
+      ...cssModules,
+    };
+  }
+
   const cssLoader = {
     loader: isServer ? 'css-loader/locals' : 'css-loader',
-    options: {
-      modules: cssModules,
-      minimize: !dev,
-      sourceMap: dev,
-      importLoaders: 1
-    }
-  }
+    options,
+  };
 
   const postcssConfig = findUp.sync('postcss.config.js', {
     cwd: config.context

--- a/packages/next-css/css-loader-config.js
+++ b/packages/next-css/css-loader-config.js
@@ -8,10 +8,10 @@ module.exports = (
   const cssLoader = {
     loader: isServer ? 'css-loader/locals' : 'css-loader',
     options: {
+      modules: cssModules,
       minimize: !dev,
       sourceMap: dev,
       importLoaders: 1,
-      modules: cssModules,
       ...cssLoaderOptions,
     },
   };

--- a/packages/next-css/css-loader-config.js
+++ b/packages/next-css/css-loader-config.js
@@ -3,26 +3,17 @@ const findUp = require('find-up')
 module.exports = (
   config,
   extractPlugin,
-  { cssModules = false, dev, isServer, loaders = [] }
+  { cssModules = false, cssLoaderOptions = {}, dev, isServer, loaders = [] }
 ) => {
-  const defaultOptions = {
-    minimize: !dev,
-    sourceMap: dev,
-    importLoaders: 1,
-    modules: cssModules,
-  };
-
-  let options = defaultOptions;
-  if (typeof cssModules === "object") {
-    options = {
-      ...options,
-      ...cssModules,
-    };
-  }
-
   const cssLoader = {
     loader: isServer ? 'css-loader/locals' : 'css-loader',
-    options,
+    options: {
+      minimize: !dev,
+      sourceMap: dev,
+      importLoaders: 1,
+      modules: cssModules,
+      ...cssLoaderOptions,
+    },
   };
 
   const postcssConfig = findUp.sync('postcss.config.js', {

--- a/packages/next-css/readme.md
+++ b/packages/next-css/readme.md
@@ -94,7 +94,7 @@ Create a CSS file `styles.css`
 }
 ```
 
-Create a page file `pages/index.js`
+Create a page file `pages/index.js` that imports your stylesheet and uses the hashed class name from the stylesheet
 
 ```js
 import css from "../style.css"

--- a/packages/next-css/readme.md
+++ b/packages/next-css/readme.md
@@ -68,6 +68,36 @@ import css from "../styles.css"
 export default () => <div className={css.example}>Hello World!</div>
 ```
 
+### With CSS modules and options
+
+```js
+// next.config.js
+const withCSS = require('@zeit/next-css')
+module.exports = withCSS({
+  cssModules: {
+    modules: 1,
+    importLoaders: 1,
+    localIdentName: "[local]___[hash:base64:5]",
+  }
+})
+```
+
+Create a CSS file `styles.css`
+
+```css
+.example {
+  font-size: 50px;
+}
+```
+
+Create a page file `pages/index.js`
+
+```js
+import css from "../styles.css"
+
+export default () => <div className={css.example}>Hello World!</div>
+```
+
 ### Production usage
 
 In production the stylesheet is compiled to `.next/static/style.css`. You have to include it into the page using either [`next/head`](https://github.com/zeit/next.js#populating-head) or a custom [`_document.js`](https://github.com/zeit/next.js#custom-document). The file will be served from `/_next/static/style.css`

--- a/packages/next-css/readme.md
+++ b/packages/next-css/readme.md
@@ -70,6 +70,10 @@ export default () => <div className={css.example}>Hello World!</div>
 
 ### With CSS modules and options
 
+You can also pass a list of options to the `css-loader` by passing an object as your `cssModules` argument.
+
+For instance, [to enable locally scoped CSS modules](https://github.com/css-modules/css-modules/blob/master/docs/local-scope.md#css-modules--local-scope), you can write:
+
 ```js
 // next.config.js
 const withCSS = require('@zeit/next-css')
@@ -93,10 +97,22 @@ Create a CSS file `styles.css`
 Create a page file `pages/index.js`
 
 ```js
-import css from "../styles.css"
+import css from "../style.css"
 
-export default () => <div className={css.example}>Hello World!</div>
+const Component = props => {
+  return (
+    <div className={css.backdrop}>
+      ...
+    </div>
+  )
+}
+
+export default Component
 ```
+
+Your exported HTML will then reflect locally scoped CSS class names.
+
+For a list of supported options, [refer to the webpack `css-loader` README](https://github.com/webpack-contrib/css-loader#options).
 
 ### Production usage
 

--- a/packages/next-css/readme.md
+++ b/packages/next-css/readme.md
@@ -70,7 +70,7 @@ export default () => <div className={css.example}>Hello World!</div>
 
 ### With CSS modules and options
 
-You can also pass a list of options to the `css-loader` by passing an object as your `cssModules` argument.
+You can also pass a list of options to the `css-loader` by passing an object called `cssLoaderOptions`.
 
 For instance, [to enable locally scoped CSS modules](https://github.com/css-modules/css-modules/blob/master/docs/local-scope.md#css-modules--local-scope), you can write:
 
@@ -78,8 +78,8 @@ For instance, [to enable locally scoped CSS modules](https://github.com/css-modu
 // next.config.js
 const withCSS = require('@zeit/next-css')
 module.exports = withCSS({
-  cssModules: {
-    modules: 1,
+  cssModules: true,
+  cssLoaderOptions: {
     importLoaders: 1,
     localIdentName: "[local]___[hash:base64:5]",
   }

--- a/packages/next-less/index.js
+++ b/packages/next-less/index.js
@@ -11,7 +11,7 @@ module.exports = (nextConfig = {}) => {
       }
 
       const { dev, isServer } = options
-      const { cssModules } = nextConfig
+      const { cssModules, cssLoaderOptions } = nextConfig
       // Support the user providing their own instance of ExtractTextPlugin.
       // If extractCSSPlugin is not defined we pass the same instance of ExtractTextPlugin to all css related modules
       // So that they compile to the same file in production
@@ -32,6 +32,7 @@ module.exports = (nextConfig = {}) => {
 
       options.defaultLoaders.less = cssLoaderConfig(config, extractCSSPlugin, {
         cssModules,
+        cssLoaderOptions,
         dev,
         isServer,
         loaders: ['less-loader']

--- a/packages/next-less/readme.md
+++ b/packages/next-less/readme.md
@@ -70,6 +70,52 @@ import css from "../styles.less"
 export default () => <div className={css.example}>Hello World!</div>
 ```
 
+### With CSS modules and options
+
+You can also pass a list of options to the `css-loader` by passing an object called `cssLoaderOptions`.
+
+For instance, [to enable locally scoped CSS modules](https://github.com/css-modules/css-modules/blob/master/docs/local-scope.md#css-modules--local-scope), you can write:
+
+```js
+// next.config.js
+const withLess = require('@zeit/next-less')
+module.exports = withLess({
+  cssModules: true,
+  cssLoaderOptions: {
+    importLoaders: 1,
+    localIdentName: "[local]___[hash:base64:5]",
+  }
+})
+```
+
+Create a CSS file `styles.css`
+
+```css
+.example {
+  font-size: 50px;
+}
+```
+
+Create a page file `pages/index.js` that imports your stylesheet and uses the hashed class name from the stylesheet
+
+```js
+import css from "../style.css"
+
+const Component = props => {
+  return (
+    <div className={css.backdrop}>
+      ...
+    </div>
+  )
+}
+
+export default Component
+```
+
+Your exported HTML will then reflect locally scoped CSS class names.
+
+For a list of supported options, [refer to the webpack `css-loader` README](https://github.com/webpack-contrib/css-loader#options).
+
 ### Production usage
 
 In production the stylesheet is compiled to `.next/static/style.css`. You have to include it into the page using either [`next/head`](https://github.com/zeit/next.js#populating-head) or a custom [`_document.js`](https://github.com/zeit/next.js#custom-document). The file will be served from `/_next/static/style.css`

--- a/packages/next-sass/index.js
+++ b/packages/next-sass/index.js
@@ -4,14 +4,12 @@ const cssLoaderConfig = require('@zeit/next-css/css-loader-config')
 module.exports = (nextConfig = {}) => {
   return Object.assign({}, nextConfig, {
     webpack(config, options) {
-      if (!options.defaultLoaders) {
-        throw new Error(
-          'This plugin is not compatible with Next.js versions below 5.0.0 https://err.sh/next-plugins/upgrade'
-        )
+      if(!options.defaultLoaders) {
+        throw new Error('This plugin is not compatible with Next.js versions below 5.0.0 https://err.sh/next-plugins/upgrade')
       }
 
       const { dev, isServer } = options
-      const { cssModules } = nextConfig
+      const { cssModules, cssLoaderOptions } = nextConfig
       // Support the user providing their own instance of ExtractTextPlugin.
       // If extractCSSPlugin is not defined we pass the same instance of ExtractTextPlugin to all css related modules
       // So that they compile to the same file in production
@@ -32,6 +30,7 @@ module.exports = (nextConfig = {}) => {
 
       options.defaultLoaders.sass = cssLoaderConfig(config, extractCSSPlugin, {
         cssModules,
+        cssLoaderOptions,
         dev,
         isServer,
         loaders: ['sass-loader']
@@ -56,3 +55,4 @@ module.exports = (nextConfig = {}) => {
     }
   })
 }
+

--- a/packages/next-sass/readme.md
+++ b/packages/next-sass/readme.md
@@ -70,6 +70,53 @@ import css from "../styles.scss"
 export default () => <div className={css.example}>Hello World!</div>
 ```
 
+### With CSS modules and options
+
+You can also pass a list of options to the `css-loader` by passing an object called `cssLoaderOptions`.
+
+For instance, [to enable locally scoped CSS modules](https://github.com/css-modules/css-modules/blob/master/docs/local-scope.md#css-modules--local-scope), you can write:
+
+```js
+// next.config.js
+const withSass = require('@zeit/next-sass')
+module.exports = withSass({
+  cssModules: true,
+  cssLoaderOptions: {
+    importLoaders: 1,
+    localIdentName: "[local]___[hash:base64:5]",
+  }
+})
+```
+
+Create a CSS file `styles.css`
+
+```css
+.example {
+  font-size: 50px;
+}
+```
+
+Create a page file `pages/index.js` that imports your stylesheet and uses the hashed class name from the stylesheet
+
+```js
+import css from "../style.css"
+
+const Component = props => {
+  return (
+    <div className={css.backdrop}>
+      ...
+    </div>
+  )
+}
+
+export default Component
+```
+
+Your exported HTML will then reflect locally scoped CSS class names.
+
+For a list of supported options, [refer to the webpack `css-loader` README](https://github.com/webpack-contrib/css-loader#options).
+
+
 ### Production usage
 
 In production the stylesheet is compiled to `.next/static/style.css`. You have to include it into the page using either [`next/head`](https://github.com/zeit/next.js#populating-head) or a custom [`_document.js`](https://github.com/zeit/next.js#custom-document). The file will be served from `/_next/static/style.css`


### PR DESCRIPTION
This PR accompanies https://github.com/zeit/next-plugins/issues/15.

I can't find a way to pass options to the webpack css-loader, so this PR enables that. It should also work with `next-sass` (and other plugins relying on `next-css`).

In this update, `cssModules` accepts either a string or an object. 

If a **string**, behavior is as before (`modules` is set to the value of `cssModules`).

If an **object**, the `options` object is a join of default options and the user-specified `cssModules` object (with user-specified taking precedence).

Questions:

1) Would it be clearer to have a dedicated options argument, like `cssModulesOptions`? (I tried to make the API change as minimal as possible but maybe it's clearer as an additional argument).
2) In the example below, if a user neglects to provide a `modules` argument in the `cssModules` object they are passing, `modules` will take on an incorrect value of `[Object object]`. We could only set the value of `modules` if `cssModules` is a string. I elected to make the code more readable by omitting this, but maybe it's worth considering