### PR TITLE
Next disable cache plugin

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,6 @@
+{
+  "extends": [
+    "xo",
+    "prettier"
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.DS_STORE
+node_modules

--- a/license
+++ b/license
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018-present Zeit, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/next-disable-cache/index.js
+++ b/packages/next-disable-cache/index.js
@@ -1,0 +1,24 @@
+module.exports = (nextConfig = {}) => {
+  return Object.assign({}, nextConfig, {
+    webpack(config, options) {
+      if (!options.defaultLoaders) {
+        throw new Error(
+          'This plugin is not compatible with Next.js versions below 5.0.0 https://err.sh/next-plugins/upgrade'
+        )
+      }
+
+      config.module.rules
+        .filter(({ use = {} }) => use.loader === 'babel-loader')
+        .map(({ use = { options: {} } }) => {
+          use.options.cacheDirectory = false
+          return undefined
+        })
+
+      if (typeof nextConfig.webpack === 'function') {
+        return nextConfig.webpack(config, options)
+      }
+
+      return config
+    }
+  })
+}

--- a/packages/next-disable-cache/package.json
+++ b/packages/next-disable-cache/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@zeit/next-disable-cache",
+  "version": "0.1.0",
+  "main": "index.js",
+  "license": "MIT",
+  "repository": "zeit/next-plugins"
+}

--- a/packages/next-disable-cache/readme.md
+++ b/packages/next-disable-cache/readme.md
@@ -1,0 +1,39 @@
+# Next.js + No Babel Cache
+
+Disable the caching feature of babel in in your Next.js project
+
+See this [issue](https://github.com/zeit/next.js/issues/3164) for why this may be useful
+
+## Installation
+
+```
+npm install --save @zeit/next-disable-cache
+```
+
+or
+
+```
+yarn add @zeit/next-disable-cache
+```
+
+## Usage
+
+
+### Configuring Next.js
+
+```js
+// next.config.js
+const withDisableCache = require('@zeit/next-disable-cache')
+module.exports = withDisableCache()
+```
+Optionally, you can add your custom Next.js configuration as parameter
+
+```js
+// next.config.js
+const withDisableCache = require('@zeit/next-disable-cache')
+module.exports = withDisableCache({
+  webpack(config, options) {
+    return config
+  }
+})
+```

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,17 @@
 # yarn lockfile v1
 
 
+"@zeit/next-css@^0.0.6":
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/@zeit/next-css/-/next-css-0.0.6.tgz#2b518404dc7f65dc1f619f7012eac3d0e2c9eb6c"
+  dependencies:
+    css-loader "^0.28.9"
+    extract-text-webpack-plugin "^3.0.2"
+    find-up "^2.1.0"
+    ignore-loader "^0.1.2"
+    postcss-loader "^2.0.10"
+    style-loader "^0.19.1"
+
 abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"


### PR DESCRIPTION
- Made a plugin based on [this](https://github.com/zeit/next.js/issues/3164). Allowing for the disabling of babel's caching.

Also added
- `.eslintrc` because I failed precommit without knowing it because my sublime linter did not pick up the configuration 
- `license` filled out with MIT text

