### PR TITLE
[WIP] Add basic transpile plugin

### DIFF
--- a/packages/next-transpile-modules/index.js
+++ b/packages/next-transpile-modules/index.js
@@ -1,0 +1,41 @@
+module.exports = (nextConfig = {}) => {
+
+  const { transpileModules = [] } = nextConfig
+  const includes = transpileModules.map(module => (new RegExp(`${module}(?!.*node_modules)`)))
+  const excludes = transpileModules.map(module => (new RegExp(`node_modules(?!\/${module}(?!.*node_modules))`)))
+
+  return Object.assign({}, nextConfig, {
+    webpack(config, options) {
+      if (!options.defaultLoaders) {
+        throw new Error(
+          'This plugin is not compatible with Next.js versions below 5.0.0 https://err.sh/next-plugins/upgrade'
+        )
+      }
+
+      config.resolve.symlinks = false
+      config.externals = config.externals.map(external => {
+        if (typeof external !== 'function') return external
+        return (ctx, req, cb) =>
+          (Boolean(includes.find(include => include.test(req))) ? cb() : external(ctx, req, cb))
+      })
+      
+      config.module.rules.push({
+        test: /\.+(js|jsx)$/,
+        loader: defaultLoaders.babel,
+        include: includes
+      })
+
+      if (typeof nextConfig.webpack === 'function') {
+        return nextConfig.webpack(config, options)
+      }
+
+      return config
+    },
+
+    webpackDevMiddleware(config) {
+      const ignored = [config.watchOptions.ignored[0]].concat(excludes)
+      config.watchOptions.ignored = ignored
+      return config
+    }
+  })
+}

--- a/packages/next-transpile-modules/package.json
+++ b/packages/next-transpile-modules/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@zeit/next-css",
+  "version": "0.0.7",
+  "main": "index.js",
+  "license": "MIT",
+  "repository": "zeit/next-plugins",
+  "dependencies": {
+    "css-loader": "^0.28.9",
+    "extract-text-webpack-plugin": "^3.0.2",
+    "find-up": "^2.1.0",
+    "ignore-loader": "^0.1.2",
+    "postcss-loader": "^2.0.10",
+    "style-loader": "^0.19.1"
+  },
+  "devDependencies": {
+    "webpack": "^3.10.0"
+  }
+}

--- a/packages/next-transpile-modules/package.json
+++ b/packages/next-transpile-modules/package.json
@@ -1,17 +1,10 @@
 {
-  "name": "@zeit/next-css",
-  "version": "0.0.7",
+  "name": "@zeit/next-transpile-modules",
+  "version": "0.0.1",
   "main": "index.js",
   "license": "MIT",
   "repository": "zeit/next-plugins",
-  "dependencies": {
-    "css-loader": "^0.28.9",
-    "extract-text-webpack-plugin": "^3.0.2",
-    "find-up": "^2.1.0",
-    "ignore-loader": "^0.1.2",
-    "postcss-loader": "^2.0.10",
-    "style-loader": "^0.19.1"
-  },
+  "dependencies": {},
   "devDependencies": {
     "webpack": "^3.10.0"
   }

--- a/packages/next-transpile-modules/readme.md
+++ b/packages/next-transpile-modules/readme.md
@@ -1,0 +1,158 @@
+# Next.js + CSS
+
+Import `.css` files in your Next.js project
+
+## Installation
+
+```
+npm install --save @zeit/next-css
+```
+
+or
+
+```
+yarn add @zeit/next-css
+```
+
+## Usage
+
+### Without CSS modules
+
+Create a `next.config.js` in your project
+
+```js
+// next.config.js
+const withCSS = require('@zeit/next-css')
+module.exports = withCSS()
+```
+
+Create a CSS file `styles.css`
+
+```css
+.example {
+  font-size: 50px;
+}
+```
+
+Create a page file `pages/index.js`
+
+```js
+import "../styles.css"
+
+export default () => <div className="example">Hello World!</div>
+```
+
+### With CSS modules
+
+```js
+// next.config.js
+const withCSS = require('@zeit/next-css')
+module.exports = withCSS({
+  cssModules: true
+})
+```
+
+Create a CSS file `styles.css`
+
+```css
+.example {
+  font-size: 50px;
+}
+```
+
+Create a page file `pages/index.js`
+
+```js
+import css from "../styles.css"
+
+export default () => <div className={css.example}>Hello World!</div>
+```
+
+### Production usage
+
+In production the stylesheet is compiled to `.next/static/style.css`. You have to include it into the page using either [`next/head`](https://github.com/zeit/next.js#populating-head) or a custom [`_document.js`](https://github.com/zeit/next.js#custom-document). The file will be served from `/_next/static/style.css`
+
+```js
+// pages/index.js
+import Head from 'next/head'
+
+export default () => {
+  return <div>
+    <Head>
+      <link rel="stylesheet" href="/_next/static/style.css">
+    </Head>
+  </div>
+}
+```
+
+```js
+// ./pages/_document.js
+import Document, { Head, Main, NextScript } from 'next/document'
+
+export default class MyDocument extends Document {
+  render() {
+    return (
+      <html>
+        <Head>
+          <link rel="stylesheet" href="/_next/static/style.css">
+        </Head>
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </html>
+    )
+  }
+}
+```
+
+
+### PostCSS plugins
+
+Create a `next.config.js` in your project
+
+```js
+// next.config.js
+const withCSS = require('@zeit/next-css')
+module.exports = withCSS()
+```
+
+Create a `postcss.config.js`
+
+```js
+module.exports = {
+  plugins: {
+    // Illustrational
+    'postcss-css-variables': {}
+  }
+}
+```
+
+Create a CSS file `styles.css` the CSS here is using the css-variables postcss plugin.
+
+```css
+:root {
+  --some-color: red;
+}
+
+.example {
+  /* red */
+  color: var(--some-color);
+}
+```
+
+When `postcss.config.js` is not found `postcss-loader` will not be added and will not cause overhead.
+
+### Configuring Next.js
+
+Optionally you can add your custom Next.js configuration as parameter
+
+```js
+// next.config.js
+const withCSS = require('@zeit/next-css')
+module.exports = withCSS({
+  webpack(config, options) {
+    return config
+  }
+})
+```


### PR DESCRIPTION
Thanks to the great example here:
https://github.com/zeit/next.js/pull/3732/files

With our powers combined, here's a plugin to allow us to add untranspiled modules to be compiled via Next's babel. 

__TODO__
- [ ] test
- [ ] write docs