### PR TITLE
Add support for multiple entry files to next-css

### DIFF
--- a/packages/next-css/index.js
+++ b/packages/next-css/index.js
@@ -1,4 +1,5 @@
 const ExtractTextPlugin = require('extract-text-webpack-plugin')
+const MergeFilesPlugin = require('merge-files-webpack-plugin')
 const cssLoaderConfig = require('./css-loader-config')
 
 module.exports = (nextConfig = {}) => {
@@ -20,9 +21,19 @@ module.exports = (nextConfig = {}) => {
 
       if (!extractCSSPlugin) {
         extractCSSPlugin = new ExtractTextPlugin({
-          filename: 'static/style.css'
+          filename: 'static/styles/[name].css'
         })
         config.plugins.push(extractCSSPlugin)
+
+        if (!isServer) {
+          config.plugins.push(
+            new MergeFilesPlugin({
+              filename: 'static/style.css',
+              test: /static\/styles\/(.+)\.css$/
+            })
+          )
+        }
+
         options.extractCSSPlugin = extractCSSPlugin
       }
 

--- a/packages/next-css/package.json
+++ b/packages/next-css/package.json
@@ -9,6 +9,7 @@
     "extract-text-webpack-plugin": "^3.0.2",
     "find-up": "^2.1.0",
     "ignore-loader": "^0.1.2",
+    "merge-files-webpack-plugin": "^1.1.2",
     "postcss-loader": "^2.0.10",
     "style-loader": "^0.19.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,17 @@
 # yarn lockfile v1
 
 
+"@zeit/next-css@^0.0.6":
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/@zeit/next-css/-/next-css-0.0.6.tgz#2b518404dc7f65dc1f619f7012eac3d0e2c9eb6c"
+  dependencies:
+    css-loader "^0.28.9"
+    extract-text-webpack-plugin "^3.0.2"
+    find-up "^2.1.0"
+    ignore-loader "^0.1.2"
+    postcss-loader "^2.0.10"
+    style-loader "^0.19.1"
+
 abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
@@ -2928,6 +2939,10 @@ meow@^3.4.2, meow@^3.7.0:
     read-pkg-up "^1.0.1"
     redent "^1.0.0"
     trim-newlines "^1.0.0"
+
+merge-files-webpack-plugin@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/merge-files-webpack-plugin/-/merge-files-webpack-plugin-1.1.2.tgz#875f4e6af008444890014cbd5a7f0169a0049c5c"
 
 micromatch@^2.1.5:
   version "2.3.11"


### PR DESCRIPTION
`next-css` only includes CSS that is imported for the index page of a project in production. @stephenmathieson put together an example project here which demonstrates the issue: https://github.com/stephenmathieson/next-plugins-css-bug

The crux of the issue is that `ExtractTextPlugin` should be creating multiple files (one for each entry), but when a static path is specified for the `filename` the output is always replaced with the last one. From the readme for [extract-text-webpack-plugin](https://github.com/webpack-contrib/extract-text-webpack-plugin):

> ExtractTextPlugin generates a file per entry, so you must use [name], [id] or [contenthash] when using multiple entries.

Based on [this issue from the ExtractTextPlugin repo](https://github.com/webpack-contrib/extract-text-webpack-plugin/issues/179), the recommended approach for combining the output would be to use [merge-files-webpack-plugin](https://github.com/jtefera/merge-text-webpack), which allows us to combine the output from `ExtractTextPlugin` into a single CSS file.

This PR implements `MergeFilesPlugin` in `next-css` so that the resulting file (`/static/style.css`) contains the extracted CSS for all entries.