### PR TITLE
Add hot-self-accept-loader for typescript

### DIFF
--- a/packages/next-typescript/index.js
+++ b/packages/next-typescript/index.js
@@ -1,15 +1,25 @@
 module.exports = (nextConfig = {}) => {
   return Object.assign({}, nextConfig, {
     webpack(config, options) {
+      const path = require('path')
       if (!options.defaultLoaders) {
         throw new Error(
           'This plugin is not compatible with Next.js versions below 5.0.0 https://err.sh/next-plugins/upgrade'
         )
       }
 
-      const { dir, defaultLoaders } = options
+      const { dir, defaultLoaders, dev, isServer } = options
 
       config.resolve.extensions.push('.ts', '.tsx')
+
+      if (dev && !isServer) {
+        config.module.rules.push({
+          test: /\.(ts|tsx)(\?[^?]*)?$/,
+          loader: 'hot-self-accept-loader',
+          include: [path.join(dir, 'pages')]
+        })
+      }
+
       config.module.rules.push({
         test: /\.+(ts|tsx)$/,
         include: [dir],


### PR DESCRIPTION
Fixes https://github.com/zeit/next.js/issues/3766

This enabled hot module replacement for typescript.