### PR TITLE
BUGFIX: Only alias react to preact-compat in production

### DIFF
--- a/packages/next-preact/index.js
+++ b/packages/next-preact/index.js
@@ -11,10 +11,12 @@ module.exports = (nextConfig = {}) => {
         config.externals = ['react', 'react-dom', ...config.externals]
       }
 
-      config.resolve.alias = Object.assign({}, config.resolve.alias, {
-        react: 'preact-compat',
-        'react-dom': 'preact-compat'
-      })
+      if (!options.dev) {
+        config.resolve.alias = Object.assign({}, config.resolve.alias, {
+          react: 'preact-compat',
+          'react-dom': 'preact-compat'
+        })
+      }
 
       if (typeof nextConfig.webpack === 'function') {
         return nextConfig.webpack(config, options)


### PR DESCRIPTION
Only aliases `react` to `preact-compat` when running in production.

Solves issue https://github.com/zeit/next.js/issues/3774