### PR TITLE
Add extracted-loader

### DIFF
--- a/packages/next-css/css-loader-config.js
+++ b/packages/next-css/css-loader-config.js
@@ -12,9 +12,9 @@ module.exports = (
       minimize: !dev,
       sourceMap: dev,
       importLoaders: 1,
-      ...cssLoaderOptions,
-    },
-  };
+      ...cssLoaderOptions
+    }
+  }
 
   const postcssConfig = findUp.sync('postcss.config.js', {
     cwd: config.context
@@ -42,14 +42,10 @@ module.exports = (
     return [cssLoader, postcssLoader, ...loaders].filter(Boolean)
   }
 
-  return extractPlugin.extract({
-    use: [cssLoader, postcssLoader, ...loaders].filter(Boolean),
-    // Use style-loader in development
-    fallback: {
-      loader: 'style-loader',
-      options: {
-        sourceMap: dev
-      }
-    }
-  })
+  return [
+    dev && 'extracted-loader',
+    ...extractPlugin.extract({
+      use: [cssLoader, postcssLoader, ...loaders].filter(Boolean)
+    })
+  ].filter(Boolean)
 }

--- a/packages/next-css/css-loader-config.js
+++ b/packages/next-css/css-loader-config.js
@@ -5,17 +5,6 @@ module.exports = (
   extractPlugin,
   { cssModules = false, cssLoaderOptions = {}, dev, isServer, loaders = [] }
 ) => {
-  const cssLoader = {
-    loader: isServer ? 'css-loader/locals' : 'css-loader',
-    options: {
-      modules: cssModules,
-      minimize: !dev,
-      sourceMap: dev,
-      importLoaders: 1,
-      ...cssLoaderOptions
-    }
-  }
-
   const postcssConfig = findUp.sync('postcss.config.js', {
     cwd: config.context
   })
@@ -29,6 +18,17 @@ module.exports = (
           path: postcssConfig
         }
       }
+    }
+  }
+
+  const cssLoader = {
+    loader: isServer ? 'css-loader/locals' : 'css-loader',
+    options: {
+      modules: cssModules,
+      minimize: !dev,
+      sourceMap: dev,
+      importLoaders: loaders.length + (postcssLoader ? 1 : 0),
+      ...cssLoaderOptions
     }
   }
 

--- a/packages/next-css/index.js
+++ b/packages/next-css/index.js
@@ -30,10 +30,6 @@ module.exports = (nextConfig = {}) => {
         }
       }
 
-      if (!extractCSSPlugin.options.disable) {
-        extractCSSPlugin.options.disable = dev
-      }
-
       options.defaultLoaders.css = cssLoaderConfig(config, extractCSSPlugin, {
         cssModules,
         dev,

--- a/packages/next-css/package.json
+++ b/packages/next-css/package.json
@@ -7,6 +7,7 @@
   "dependencies": {
     "css-loader": "^0.28.9",
     "extract-text-webpack-plugin": "^3.0.2",
+    "extracted-loader": "^1.0.4",
     "find-up": "^2.1.0",
     "ignore-loader": "^0.1.2",
     "postcss-loader": "^2.0.10",

--- a/packages/next-css/readme.md
+++ b/packages/next-css/readme.md
@@ -16,6 +16,30 @@ yarn add @zeit/next-css
 
 ## Usage
 
+
+The stylesheet is compiled to `.next/static/style.css`. You have to include it into the page a custom [`_document.js`](https://github.com/zeit/next.js#custom-document). The file will be served from `/_next/static/style.css`
+
+```js
+// ./pages/_document.js
+import Document, { Head, Main, NextScript } from 'next/document'
+
+export default class MyDocument extends Document {
+  render() {
+    return (
+      <html>
+        <Head>
+          <link rel="stylesheet" href="/_next/static/style.css" />
+        </Head>
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </html>
+    )
+  }
+}
+```
+
 ### Without CSS modules
 
 Create a `next.config.js` in your project
@@ -113,23 +137,6 @@ export default Component
 Your exported HTML will then reflect locally scoped CSS class names.
 
 For a list of supported options, [refer to the webpack `css-loader` README](https://github.com/webpack-contrib/css-loader#options).
-
-### Production usage
-
-In production the stylesheet is compiled to `.next/static/style.css`. You have to include it into the page using either [`next/head`](https://github.com/zeit/next.js#populating-head) or a custom [`_document.js`](https://github.com/zeit/next.js#custom-document). The file will be served from `/_next/static/style.css`
-
-```js
-// pages/index.js
-import Head from 'next/head'
-
-export default () => {
-  return <div>
-    <Head>
-      <link rel="stylesheet" href="/_next/static/style.css" />
-    </Head>
-  </div>
-}
-```
 
 ```js
 // ./pages/_document.js

--- a/packages/next-css/readme.md
+++ b/packages/next-css/readme.md
@@ -16,8 +16,7 @@ yarn add @zeit/next-css
 
 ## Usage
 
-
-The stylesheet is compiled to `.next/static/style.css`. You have to include it into the page a custom [`_document.js`](https://github.com/zeit/next.js#custom-document). The file will be served from `/_next/static/style.css`
+The stylesheet is compiled to `.next/static/style.css`. You have to include it into the page using a custom [`_document.js`](https://github.com/zeit/next.js#custom-document). The file will be served from `/_next/static/style.css`
 
 ```js
 // ./pages/_document.js

--- a/packages/next-less/index.js
+++ b/packages/next-less/index.js
@@ -30,10 +30,6 @@ module.exports = (nextConfig = {}) => {
         }
       }
 
-      if (!extractCSSPlugin.options.disable) {
-        extractCSSPlugin.options.disable = dev
-      }
-
       options.defaultLoaders.less = cssLoaderConfig(config, extractCSSPlugin, {
         cssModules,
         cssLoaderOptions,

--- a/packages/next-less/readme.md
+++ b/packages/next-less/readme.md
@@ -16,6 +16,29 @@ yarn add @zeit/next-less less
 
 ## Usage
 
+The stylesheet is compiled to `.next/static/style.css`. You have to include it into the page using a custom [`_document.js`](https://github.com/zeit/next.js#custom-document). The file will be served from `/_next/static/style.css`
+
+```js
+// ./pages/_document.js
+import Document, { Head, Main, NextScript } from 'next/document'
+
+export default class MyDocument extends Document {
+  render() {
+    return (
+      <html>
+        <Head>
+          <link rel="stylesheet" href="/_next/static/style.css" />
+        </Head>
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </html>
+    )
+  }
+}
+```
+
 ### Without CSS modules
 
 Create a `next.config.js` in your project
@@ -115,23 +138,6 @@ export default Component
 Your exported HTML will then reflect locally scoped CSS class names.
 
 For a list of supported options, [refer to the webpack `css-loader` README](https://github.com/webpack-contrib/css-loader#options).
-
-### Production usage
-
-In production the stylesheet is compiled to `.next/static/style.css`. You have to include it into the page using either [`next/head`](https://github.com/zeit/next.js#populating-head) or a custom [`_document.js`](https://github.com/zeit/next.js#custom-document). The file will be served from `/_next/static/style.css`
-
-```js
-// pages/index.js
-import Head from 'next/head'
-
-export default () => {
-  return <div>
-    <Head>
-      <link rel="stylesheet" href="/_next/static/style.css" />
-    </Head>
-  </div>
-}
-```
 
 ```js
 // ./pages/_document.js

--- a/packages/next-sass/index.js
+++ b/packages/next-sass/index.js
@@ -34,10 +34,6 @@ module.exports = (nextConfig = {}) => {
         }
       }
 
-      if (!extractCSSPlugin.options.disable) {
-        extractCSSPlugin.options.disable = dev
-      }
-
       options.defaultLoaders.sass = cssLoaderConfig(config, extractCSSPlugin, {
         cssModules,
         cssLoaderOptions,

--- a/packages/next-sass/readme.md
+++ b/packages/next-sass/readme.md
@@ -16,6 +16,29 @@ yarn add @zeit/next-sass node-sass
 
 ## Usage
 
+The stylesheet is compiled to `.next/static/style.css`. You have to include it into the page using a custom [`_document.js`](https://github.com/zeit/next.js#custom-document). The file will be served from `/_next/static/style.css`
+
+```js
+// ./pages/_document.js
+import Document, { Head, Main, NextScript } from 'next/document'
+
+export default class MyDocument extends Document {
+  render() {
+    return (
+      <html>
+        <Head>
+          <link rel="stylesheet" href="/_next/static/style.css" />
+        </Head>
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </html>
+    )
+  }
+}
+```
+
 ### Without CSS modules
 
 Create a `next.config.js` in your project
@@ -128,23 +151,6 @@ module.exports = withSass({
     includePaths: ["absolute/path/a", "absolute/path/b"]
   }
 })
-```
-
-### Production usage
-
-In production the stylesheet is compiled to `.next/static/style.css`. You have to include it into the page using either [`next/head`](https://github.com/zeit/next.js#populating-head) or a custom [`_document.js`](https://github.com/zeit/next.js#custom-document). The file will be served from `/_next/static/style.css`
-
-```js
-// pages/index.js
-import Head from 'next/head'
-
-export default () => {
-  return <div>
-    <Head>
-      <link rel="stylesheet" href="/_next/static/style.css">
-    </Head>
-  </div>
-}
 ```
 
 ```js

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,16 @@
 # Next.js Plugins
 
-Official Next.js plugins
+## Official Next.js plugins
+
+[@zeit/next-css](./packages/next-css)
+[@zeit/next-sass](./packages/next-sass)
+[@zeit/next-less](./packages/next-less)
+[@zeit/next-preact](./packages/next-preact)
+[@zeit/next-typescript](./packages/next-typescript)
+
+## Community made plugins
+
+[next-offline](https://github.com/hanford/next-offline)
 
 ## Adding a plugin
 

--- a/readme.md
+++ b/readme.md
@@ -2,15 +2,15 @@
 
 ## Official Next.js plugins
 
-[@zeit/next-css](./packages/next-css)
-[@zeit/next-sass](./packages/next-sass)
-[@zeit/next-less](./packages/next-less)
-[@zeit/next-preact](./packages/next-preact)
-[@zeit/next-typescript](./packages/next-typescript)
+- [@zeit/next-css](./packages/next-css)
+- [@zeit/next-sass](./packages/next-sass)
+- [@zeit/next-less](./packages/next-less)
+- [@zeit/next-preact](./packages/next-preact)
+- [@zeit/next-typescript](./packages/next-typescript)
 
 ## Community made plugins
 
-[next-offline](https://github.com/hanford/next-offline)
+- [next-offline](https://github.com/hanford/next-offline)
 
 ## Adding a plugin
 

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@ Official Next.js plugins
 
 ## Adding a plugin
 
-Before adding a plugin in this repository please create an issue to establish if it should be an official plugin or not.
+> :warning: Before adding a plugin in this repository please create an issue to establish if it should be an official plugin or not.
 
 1. Create a directory under the `packages` folder
 2. Add `package.json` to the directory with these contents:

--- a/readme.md
+++ b/readme.md
@@ -1,8 +1,10 @@
 # Next.js Plugins
 
-Community maintained Next.js plugins
+Official Next.js plugins
 
 ## Adding a plugin
+
+Before adding a plugin in this repository please create an issue to establish if it should be an official plugin or not.
 
 1. Create a directory under the `packages` folder
 2. Add `package.json` to the directory with these contents:

--- a/yarn.lock
+++ b/yarn.lock
@@ -1718,6 +1718,10 @@ extract-text-webpack-plugin@^3.0.2:
     schema-utils "^0.3.0"
     webpack-sources "^1.0.1"
 
+extracted-loader@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/extracted-loader/-/extracted-loader-1.0.4.tgz#e1a3f1791813c14091a1959e261e23e95dd90115"
+
 extsprintf@1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.3.0.tgz#96918440e3041a7a414f8c52e3c574eb3c3e1e05"


### PR DESCRIPTION
Fixes #25, #20 
:wave: FOUC when using next-css.

This adds https://github.com/sheerun/extracted-loader which works on the extracted stylesheet.

Thanks @sheerun for the loader :pray: