### PR TITLE
Move styles to commons chunk in development

### DIFF
--- a/packages/next-css/index.js
+++ b/packages/next-css/index.js
@@ -25,7 +25,7 @@ module.exports = (nextConfig = {}) => {
         })
         config.plugins.push(extractCSSPlugin)
         options.extractCSSPlugin = extractCSSPlugin
-        if (!dev && !isServer) {
+        if (!isServer) {
           config = commonsChunkConfig(config)
         }
       }

--- a/packages/next-less/index.js
+++ b/packages/next-less/index.js
@@ -25,7 +25,7 @@ module.exports = (nextConfig = {}) => {
         })
         config.plugins.push(extractCSSPlugin)
         options.extractCSSPlugin = extractCSSPlugin
-        if (!dev && !isServer) {
+        if (!isServer) {
           config = commonsChunkConfig(config, /\.less$/)
         }
       }

--- a/packages/next-sass/index.js
+++ b/packages/next-sass/index.js
@@ -29,7 +29,7 @@ module.exports = (nextConfig = {}) => {
         })
         config.plugins.push(extractCSSPlugin)
         options.extractCSSPlugin = extractCSSPlugin
-        if (!dev && !isServer) {
+        if (!isServer) {
           config = commonsChunkConfig(config, /\.(scss|sass)$/)
         }
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,17 +2,6 @@
 # yarn lockfile v1
 
 
-"@zeit/next-css@^0.0.6":
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/@zeit/next-css/-/next-css-0.0.6.tgz#2b518404dc7f65dc1f619f7012eac3d0e2c9eb6c"
-  dependencies:
-    css-loader "^0.28.9"
-    extract-text-webpack-plugin "^3.0.2"
-    find-up "^2.1.0"
-    ignore-loader "^0.1.2"
-    postcss-loader "^2.0.10"
-    style-loader "^0.19.1"
-
 abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"


### PR DESCRIPTION
With https://github.com/zeit/next-plugins/pull/50, we now have a similar issue in development that we previously had in production where styles from multiple pages are not extracted properly to `/static/style.css`.

This updates the css, less, & sass plugins to also apply the `CommonsChunkConfig` changes in development (which is necessary now that we are always using the `ExtractTextPlugin`).