### PR TITLE
Add options generators for css/postcss/less/sass/ts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_STORE
 node_modules
+.idea

--- a/packages/next-css/css-loader-config.js
+++ b/packages/next-css/css-loader-config.js
@@ -3,24 +3,32 @@ const findUp = require('find-up')
 module.exports = (
   config,
   extractPlugin,
-  { cssLoaderOptions = {}, postcssLoaderOptions = null, dev, isServer, loaders = [] }
-) => {
-  
-  if (postcssLoaderOptions instanceof Function) {
-    cssLoaderOptions = postcssLoaderOptions({dev, isServer})
+  {
+    cssLoaderOptions = {},
+    postcssLoaderOptions = null,
+    dev,
+    isServer,
+    loaders = []
   }
-  
+) => {
+  if (cssLoaderOptions instanceof Function) {
+    cssLoaderOptions = cssLoaderOptions({ dev, isServer })
+  }
+
   let postcssLoader
   if (postcssLoaderOptions !== null) {
     const postcssConfigPath = findUp.sync('postcss.config.js', {
       cwd: config.context
     })
-  
+
     if (postcssLoaderOptions instanceof Function) {
-      postcssLoaderOptions = postcssLoaderOptions({dev, isServer, path: postcssConfigPath}) || {}
+      postcssLoaderOptions =
+        postcssLoaderOptions({ dev, isServer, path: postcssConfigPath }) || {}
     }
     if (!postcssLoaderOptions.config || !postcssLoaderOptions.config.path) {
-      postcssLoaderOptions.config = Object.assign(postcssLoaderOptions.config, { path: postcssConfigPath })
+      postcssLoaderOptions.config = Object.assign(postcssLoaderOptions.config, {
+        path: postcssConfigPath
+      })
     }
     postcssLoader = {
       loader: 'postcss-loader',

--- a/packages/next-css/css-loader-config.js
+++ b/packages/next-css/css-loader-config.js
@@ -17,23 +17,37 @@ module.exports = (
   }
 
   let postcssLoader
-  if (postcssLoaderOptions !== null) {
-    const postcssConfigPath = findUp.sync('postcss.config.js', {
-      cwd: config.context
-    })
+  const postcssConfigPath = findUp.sync('postcss.config.js', {
+    cwd: config.context
+  })
 
+  if (postcssLoaderOptions !== null) {
     if (postcssLoaderOptions instanceof Function) {
-      postcssLoaderOptions =
-        postcssLoaderOptions({ dev, isServer, path: postcssConfigPath }) || {}
+      postcssLoaderOptions = postcssLoaderOptions({ dev, isServer }) || {}
     }
-    if (!postcssLoaderOptions.config || !postcssLoaderOptions.config.path) {
-      postcssLoaderOptions.config = Object.assign(postcssLoaderOptions.config, {
-        path: postcssConfigPath
-      })
+    if (postcssConfigPath) {
+      if (!postcssLoaderOptions.config || !postcssLoaderOptions.config.path) {
+        postcssLoaderOptions.config = Object.assign(
+          {},
+          postcssLoaderOptions.config,
+          {
+            path: postcssConfigPath
+          }
+        )
+      }
     }
     postcssLoader = {
       loader: 'postcss-loader',
       options: postcssLoaderOptions
+    }
+  } else if (postcssConfigPath) {
+    postcssLoader = {
+      loader: 'postcss-loader',
+      options: {
+        config: {
+          path: postcssConfigPath
+        }
+      }
     }
   }
 

--- a/packages/next-css/css-loader-config.js
+++ b/packages/next-css/css-loader-config.js
@@ -4,6 +4,7 @@ module.exports = (
   config,
   extractPlugin,
   {
+    cssModules = false,
     cssLoaderOptions = {},
     postcssLoaderOptions = null,
     dev,
@@ -39,6 +40,7 @@ module.exports = (
   const cssLoader = {
     loader: isServer ? 'css-loader/locals' : 'css-loader',
     options: {
+      modules: cssModules,
       minimize: !dev,
       sourceMap: dev,
       importLoaders: loaders.length + (postcssLoader ? 1 : 0),

--- a/packages/next-css/index.js
+++ b/packages/next-css/index.js
@@ -12,7 +12,7 @@ module.exports = (nextConfig = {}) => {
       }
 
       const { dev, isServer } = options
-      const { cssLoaderOptions, postcssLoaderOptions } = nextConfig
+      const { cssLoaderOptions, postcssLoaderOptions, cssModules } = nextConfig
       // Support the user providing their own instance of ExtractTextPlugin.
       // If extractCSSPlugin is not defined we pass the same instance of ExtractTextPlugin to all css related modules
       // So that they compile to the same file in production
@@ -31,12 +31,13 @@ module.exports = (nextConfig = {}) => {
       }
 
       options.defaultLoaders.css = cssLoaderConfig(config, extractCSSPlugin, {
+        cssModules,
         cssLoaderOptions,
         postcssLoaderOptions,
         dev,
         isServer
       })
-      
+
       config.module.rules.push({
         test: /\.css$/,
         use: options.defaultLoaders.css

--- a/packages/next-css/index.js
+++ b/packages/next-css/index.js
@@ -12,7 +12,7 @@ module.exports = (nextConfig = {}) => {
       }
 
       const { dev, isServer } = options
-      const { cssModules } = nextConfig
+      const { cssLoaderOptions, postcssLoaderOptions } = nextConfig
       // Support the user providing their own instance of ExtractTextPlugin.
       // If extractCSSPlugin is not defined we pass the same instance of ExtractTextPlugin to all css related modules
       // So that they compile to the same file in production
@@ -31,11 +31,12 @@ module.exports = (nextConfig = {}) => {
       }
 
       options.defaultLoaders.css = cssLoaderConfig(config, extractCSSPlugin, {
-        cssModules,
+        cssLoaderOptions,
+        postcssLoaderOptions,
         dev,
         isServer
       })
-
+      
       config.module.rules.push({
         test: /\.css$/,
         use: options.defaultLoaders.css

--- a/packages/next-css/index.js
+++ b/packages/next-css/index.js
@@ -13,6 +13,7 @@ module.exports = (nextConfig = {}) => {
 
       const { dev, isServer } = options
       const { cssLoaderOptions, postcssLoaderOptions, cssModules } = nextConfig
+      let { rules = {} } = nextConfig
       // Support the user providing their own instance of ExtractTextPlugin.
       // If extractCSSPlugin is not defined we pass the same instance of ExtractTextPlugin to all css related modules
       // So that they compile to the same file in production
@@ -38,10 +39,14 @@ module.exports = (nextConfig = {}) => {
         isServer
       })
 
-      config.module.rules.push({
-        test: /\.css$/,
+      if (rules instanceof Function) {
+        rules = rules({ dev, isServer })
+      }
+
+      rules = Object.assign({ test: /\.css$/ }, rules, {
         use: options.defaultLoaders.css
       })
+      config.module.rules.push(rules)
 
       if (typeof nextConfig.webpack === 'function') {
         return nextConfig.webpack(config, options)

--- a/packages/next-css/readme.md
+++ b/packages/next-css/readme.md
@@ -71,7 +71,9 @@ export default () => <div className="example">Hello World!</div>
 // next.config.js
 const withCSS = require('@zeit/next-css')
 module.exports = withCSS({
-  cssModules: true
+  cssLoaderOptions: {
+    modules: true
+  }
 })
 ```
 
@@ -93,7 +95,8 @@ export default () => <div className={css.example}>Hello World!</div>
 
 ### With CSS modules and options
 
-You can also pass a list of options to the `css-loader` by passing an object called `cssLoaderOptions`.
+You can also pass a list of options to the `css-loader` by passing an object or a function called `cssLoaderOptions`.
+If you pass a function, it will receive an object with `dev` and `isServer` fields.  
 
 For instance, [to enable locally scoped CSS modules](https://github.com/css-modules/css-modules/blob/master/docs/local-scope.md#css-modules--local-scope), you can write:
 
@@ -101,11 +104,11 @@ For instance, [to enable locally scoped CSS modules](https://github.com/css-modu
 // next.config.js
 const withCSS = require('@zeit/next-css')
 module.exports = withCSS({
-  cssModules: true,
-  cssLoaderOptions: {
+  cssLoaderOptions: ({ dev }) => ({
+    modules: true,
     importLoaders: 1,
-    localIdentName: "[local]___[hash:base64:5]",
-  }
+    localIdentName: dev ? "[local]___[hash:base64:5]" : "[hash:base64:5]"
+  })
 })
 ```
 

--- a/packages/next-less/index.js
+++ b/packages/next-less/index.js
@@ -12,7 +12,7 @@ module.exports = (nextConfig = {}) => {
       }
 
       const { dev, isServer } = options
-      const { cssLoaderOptions, postcssLoaderOptions } = nextConfig
+      const { cssLoaderOptions, postcssLoaderOptions, cssModules } = nextConfig
       let { lessLoaderOptions } = nextConfig
       // Support the user providing their own instance of ExtractTextPlugin.
       // If extractCSSPlugin is not defined we pass the same instance of ExtractTextPlugin to all css related modules
@@ -30,20 +30,23 @@ module.exports = (nextConfig = {}) => {
           config = commonsChunkConfig(config, /\.less$/)
         }
       }
-      
+
       if (lessLoaderOptions instanceof Function) {
         lessLoaderOptions = lessLoaderOptions({ dev, isServer })
       }
 
       options.defaultLoaders.less = cssLoaderConfig(config, extractCSSPlugin, {
+        cssModules,
         cssLoaderOptions,
         postcssLoaderOptions,
         dev,
         isServer,
-        loaders: [{
-          loader: 'less-loader',
-          options: lessLoaderOptions
-        }]
+        loaders: [
+          {
+            loader: 'less-loader',
+            options: lessLoaderOptions
+          }
+        ]
       })
 
       config.module.rules.push({

--- a/packages/next-less/index.js
+++ b/packages/next-less/index.js
@@ -13,7 +13,7 @@ module.exports = (nextConfig = {}) => {
 
       const { dev, isServer } = options
       const { cssLoaderOptions, postcssLoaderOptions, cssModules } = nextConfig
-      let { lessLoaderOptions } = nextConfig
+      let { lessLoaderOptions = {}, rules = {} } = nextConfig
       // Support the user providing their own instance of ExtractTextPlugin.
       // If extractCSSPlugin is not defined we pass the same instance of ExtractTextPlugin to all css related modules
       // So that they compile to the same file in production
@@ -49,10 +49,14 @@ module.exports = (nextConfig = {}) => {
         ]
       })
 
-      config.module.rules.push({
-        test: /\.less$/,
+      if (rules instanceof Function) {
+        rules = rules({ dev, isServer })
+      }
+
+      rules = Object.assign({ test: /\.less$/ }, rules, {
         use: options.defaultLoaders.less
       })
+      config.module.rules.push(rules)
 
       if (typeof nextConfig.webpack === 'function') {
         return nextConfig.webpack(config, options)

--- a/packages/next-less/index.js
+++ b/packages/next-less/index.js
@@ -12,7 +12,8 @@ module.exports = (nextConfig = {}) => {
       }
 
       const { dev, isServer } = options
-      const { cssModules, cssLoaderOptions } = nextConfig
+      const { cssLoaderOptions, postcssLoaderOptions } = nextConfig
+      let { lessLoaderOptions } = nextConfig
       // Support the user providing their own instance of ExtractTextPlugin.
       // If extractCSSPlugin is not defined we pass the same instance of ExtractTextPlugin to all css related modules
       // So that they compile to the same file in production
@@ -29,13 +30,20 @@ module.exports = (nextConfig = {}) => {
           config = commonsChunkConfig(config, /\.less$/)
         }
       }
+      
+      if (lessLoaderOptions instanceof Function) {
+        lessLoaderOptions = lessLoaderOptions({ dev, isServer })
+      }
 
       options.defaultLoaders.less = cssLoaderConfig(config, extractCSSPlugin, {
-        cssModules,
         cssLoaderOptions,
+        postcssLoaderOptions,
         dev,
         isServer,
-        loaders: ['less-loader']
+        loaders: [{
+          loader: 'less-loader',
+          options: lessLoaderOptions
+        }]
       })
 
       config.module.rules.push({

--- a/packages/next-less/readme.md
+++ b/packages/next-less/readme.md
@@ -72,7 +72,9 @@ export default () => <div className="example">Hello World!</div>
 // next.config.js
 const withLess = require('@zeit/next-less')
 module.exports = withLess({
-  cssModules: true
+  cssLoaderOptions:{
+    modules: true
+  }
 })
 ```
 
@@ -95,7 +97,8 @@ export default () => <div className={css.example}>Hello World!</div>
 
 ### With CSS modules and options
 
-You can also pass a list of options to the `css-loader` by passing an object called `cssLoaderOptions`.
+You can also pass a list of options to the `css-loader` by passing an object or a function called `cssLoaderOptions`.
+If you pass a function, it will receive an object with `dev` and `isServer` fields. 
 
 For instance, [to enable locally scoped CSS modules](https://github.com/css-modules/css-modules/blob/master/docs/local-scope.md#css-modules--local-scope), you can write:
 
@@ -103,11 +106,11 @@ For instance, [to enable locally scoped CSS modules](https://github.com/css-modu
 // next.config.js
 const withLess = require('@zeit/next-less')
 module.exports = withLess({
-  cssModules: true,
-  cssLoaderOptions: {
-    importLoaders: 1,
-    localIdentName: "[local]___[hash:base64:5]",
-  }
+  cssLoaderOptions: ({ dev }) => ({
+      modules: true,
+      importLoaders: 1,
+      localIdentName: dev ? "[local]___[hash:base64:5]" : "[hash:base64:5]"
+    })
 })
 ```
 

--- a/packages/next-sass/index.js
+++ b/packages/next-sass/index.js
@@ -12,12 +12,9 @@ module.exports = (nextConfig = {}) => {
       }
 
       const { dev, isServer } = options
-      const {
-        cssLoaderOptions,
-        postcssLoaderOptions
-      } = nextConfig
-      
-      let { sassLoaderOptions= {} } = nextConfig
+      const { cssLoaderOptions, postcssLoaderOptions, cssModules } = nextConfig
+
+      let { sassLoaderOptions = {} } = nextConfig
       // Support the user providing their own instance of ExtractTextPlugin.
       // If extractCSSPlugin is not defined we pass the same instance of ExtractTextPlugin to all css related modules
       // So that they compile to the same file in production
@@ -34,12 +31,13 @@ module.exports = (nextConfig = {}) => {
           config = commonsChunkConfig(config, /\.(scss|sass)$/)
         }
       }
-  
+
       if (sassLoaderOptions instanceof Function) {
-        sassLoaderOptions = sassLoaderOptions({dev, isServer})
+        sassLoaderOptions = sassLoaderOptions({ dev, isServer })
       }
-      
+
       options.defaultLoaders.sass = cssLoaderConfig(config, extractCSSPlugin, {
+        cssModules,
         cssLoaderOptions,
         postcssLoaderOptions,
         dev,
@@ -52,12 +50,10 @@ module.exports = (nextConfig = {}) => {
         ]
       })
 
-      config.module.rules.push(
-        {
-          test: /\.(scss|sass)$/,
-          use: options.defaultLoaders.sass
-        }
-      )
+      config.module.rules.push({
+        test: /\.(scss|sass)$/,
+        use: options.defaultLoaders.sass
+      })
 
       if (typeof nextConfig.webpack === 'function') {
         return nextConfig.webpack(config, options)

--- a/packages/next-sass/index.js
+++ b/packages/next-sass/index.js
@@ -13,10 +13,11 @@ module.exports = (nextConfig = {}) => {
 
       const { dev, isServer } = options
       const {
-        cssModules,
         cssLoaderOptions,
-        sassLoaderOptions = {}
+        postcssLoaderOptions
       } = nextConfig
+      
+      let { sassLoaderOptions= {} } = nextConfig
       // Support the user providing their own instance of ExtractTextPlugin.
       // If extractCSSPlugin is not defined we pass the same instance of ExtractTextPlugin to all css related modules
       // So that they compile to the same file in production
@@ -33,10 +34,14 @@ module.exports = (nextConfig = {}) => {
           config = commonsChunkConfig(config, /\.(scss|sass)$/)
         }
       }
-
+  
+      if (sassLoaderOptions instanceof Function) {
+        sassLoaderOptions = sassLoaderOptions({dev, isServer})
+      }
+      
       options.defaultLoaders.sass = cssLoaderConfig(config, extractCSSPlugin, {
-        cssModules,
         cssLoaderOptions,
+        postcssLoaderOptions,
         dev,
         isServer,
         loaders: [
@@ -49,11 +54,7 @@ module.exports = (nextConfig = {}) => {
 
       config.module.rules.push(
         {
-          test: /\.scss$/,
-          use: options.defaultLoaders.sass
-        },
-        {
-          test: /\.sass$/,
+          test: /\.(scss|sass)$/,
           use: options.defaultLoaders.sass
         }
       )

--- a/packages/next-sass/index.js
+++ b/packages/next-sass/index.js
@@ -14,7 +14,7 @@ module.exports = (nextConfig = {}) => {
       const { dev, isServer } = options
       const { cssLoaderOptions, postcssLoaderOptions, cssModules } = nextConfig
 
-      let { sassLoaderOptions = {} } = nextConfig
+      let { sassLoaderOptions = {}, rules = {} } = nextConfig
       // Support the user providing their own instance of ExtractTextPlugin.
       // If extractCSSPlugin is not defined we pass the same instance of ExtractTextPlugin to all css related modules
       // So that they compile to the same file in production
@@ -50,10 +50,14 @@ module.exports = (nextConfig = {}) => {
         ]
       })
 
-      config.module.rules.push({
-        test: /\.(scss|sass)$/,
+      if (rules instanceof Function) {
+        rules = rules({ dev, isServer })
+      }
+
+      rules = Object.assign({ test: /\.(scss|sass)$/ }, rules, {
         use: options.defaultLoaders.sass
       })
+      config.module.rules.push(rules)
 
       if (typeof nextConfig.webpack === 'function') {
         return nextConfig.webpack(config, options)

--- a/packages/next-sass/readme.md
+++ b/packages/next-sass/readme.md
@@ -72,7 +72,9 @@ export default () => <div className="example">Hello World!</div>
 // next.config.js
 const withSass = require('@zeit/next-sass')
 module.exports = withSass({
-  cssModules: true
+  cssLoaderOptions: {
+    modules: true
+  }
 })
 ```
 
@@ -95,7 +97,8 @@ export default () => <div className={css.example}>Hello World!</div>
 
 ### With CSS modules and options
 
-You can also pass a list of options to the `css-loader` by passing an object called `cssLoaderOptions`.
+You can also pass a list of options to the `css-loader` by passing an object or a function called `cssLoaderOptions`.
+If you pass a function, it will receive an object with `dev` and `isServer` fields.
 
 For instance, [to enable locally scoped CSS modules](https://github.com/css-modules/css-modules/blob/master/docs/local-scope.md#css-modules--local-scope), you can write:
 
@@ -103,11 +106,11 @@ For instance, [to enable locally scoped CSS modules](https://github.com/css-modu
 // next.config.js
 const withSass = require('@zeit/next-sass')
 module.exports = withSass({
-  cssModules: true,
-  cssLoaderOptions: {
-    importLoaders: 1,
-    localIdentName: "[local]___[hash:base64:5]",
-  }
+  cssLoaderOptions: ({ dev }) => ({
+      modules: true,
+      importLoaders: 1,
+      localIdentName: dev ? "[local]___[hash:base64:5]" : "[hash:base64:5]"
+    })
 })
 ```
 
@@ -141,8 +144,9 @@ For a list of supported options, [refer to the webpack `css-loader` README](http
 
 ### With SASS loader options
 
-You can pass options from [node-sass](https://github.com/sass/node-sass#options)
+You can pass options from [node-sass](https://github.com/sass/node-sass#options).  
 
+If you need to use `dev` or `isServer` pass a function instead of object, which will receive `{ dev, isServer }`.
 ```js
 // next.config.js
 const withSass = require('@zeit/next-sass')

--- a/packages/next-typescript/index.js
+++ b/packages/next-typescript/index.js
@@ -21,6 +21,7 @@ module.exports = (nextConfig = {}) => {
       }
 
       const { dir, defaultLoaders, dev, isServer } = options
+      let { typescriptLoaderOptions } = options
 
       config.resolve.extensions.push('.ts', '.tsx')
 
@@ -32,6 +33,10 @@ module.exports = (nextConfig = {}) => {
         })
       }
 
+      if (typescriptLoaderOptions instanceof Function) {
+        typescriptLoaderOptions = typescriptLoaderOptions({ dev, isServer })
+      }
+      
       config.module.rules.push({
         test: /\.+(ts|tsx)$/,
         include: [dir],
@@ -45,7 +50,7 @@ module.exports = (nextConfig = {}) => {
               {
                 transpileOnly: true
               },
-              nextConfig.typescriptLoaderOptions
+              typescriptLoaderOptions
             )
           }
         ]


### PR DESCRIPTION
Make possible use `dev` and `isServer` variables in css/postcss/less/sass/ts options.
And I think, what using `cssModules` variable is not a good idea. Instead, we should pass it in `cssLoaderOptions`, since it was implemented here. Let's unify the way how to pass options. What are you thinking about that?

it will look like that
```javascript
module.exports = withSass({
  cssLoaderOptions: ({ dev }) => ({
    modules: true,
    localIdentName: dev ? '[local]-[hash:base64:5]' : '[hash:base64:5]'
  })
})
```

Of course, there is backward compatibility.

Also, it fix passing cssLoaderOptions and it adds possibility:

- to pass postCssOptions
- to pass additional fields in webpack `rule` (for example, you can pass `exclude` and `include` in rule)