### PR TITLE
Move webpack-bundle-analyzer to dependencies

### DIFF
--- a/packages/next-bundle-analyzer/package.json
+++ b/packages/next-bundle-analyzer/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "license": "MIT",
   "repository": "zeit/next-plugins",
-  "devDependencies": {
+  "dependencies": {
     "webpack-bundle-analyzer": "^2.10.0"
   }
 }


### PR DESCRIPTION
It should fix this error:
```
> BUNDLE_ANALYZE=both yarn build
yarn run v1.3.2
$ next build
> Failed to build
{ Error: Cannot find module 'webpack-bundle-analyzer'
...
```