### PR TITLE
Note of `next-awesome-typescript` alternative

### DIFF
--- a/packages/next-typescript/readme.md
+++ b/packages/next-typescript/readme.md
@@ -2,6 +2,8 @@
 
 Use [Typescript](https://www.typescriptlang.org/) with [Next.js](https://github.com/zeit/next.js)
 
+> This plugin uses `ts-loader`. If you want to load your files through `awesome-typescript-loader`, e.g. for performance reasons, you can use [`next-awesome-typescript` plugin](https://github.com/saitonakamura/next-awesome-typescript)
+
 ## Installation
 
 ```

--- a/readme.md
+++ b/readme.md
@@ -13,6 +13,7 @@
 
 - [next-offline](https://github.com/hanford/next-offline)
 - [next-plugin-graphql](https://github.com/lfades/next-plugin-graphql)
+- [next-awesome-typescript](https://github.com/saitonakamura/next-awesome-typescript)
 
 ## Adding a plugin
 


### PR DESCRIPTION
Add a note that alternative [`next-awesome-typescript` plugin](https://github.com/saitonakamura/next-awesome-typescript) is available