### PR TITLE
Add missing `main.js` conditional 

### DIFF
--- a/packages/next-css/commons-chunk-config.js
+++ b/packages/next-css/commons-chunk-config.js
@@ -3,7 +3,7 @@ module.exports = (config, test = /\.css$/) => {
   config.plugins = config.plugins.map(plugin => {
     if (
       plugin.constructor.name === 'CommonsChunkPlugin' &&
-      plugin.filenameTemplate === 'commons.js'
+      (plugin.filenameTemplate === 'commons.js' || plugin.filenameTemplate === 'main.js')
     ) {
       const defaultMinChunks = plugin.minChunks
       plugin.minChunks = (module, count) => {


### PR DESCRIPTION
Added missing `main.js` conditional on commons chunk config. Without this generated css class names don't match up on build output.