### PR TITLE
[next-preact] Add react & react-dom production.min.js aliases

### DIFF
--- a/packages/next-preact/alias.js
+++ b/packages/next-preact/alias.js
@@ -1,6 +1,8 @@
 const moduleAlias = require('module-alias')
 
 module.exports = () => {
+  moduleAlias.addAlias('react/cjs/react.production.min.js', 'preact-compat/dist/preact-compat.min.js')
+  moduleAlias.addAlias('react-dom/cjs/react-dom.production.min.js', 'preact-compat/dist/preact-compat.min.js')
   moduleAlias.addAlias('react', 'preact-compat')
   moduleAlias.addAlias('react-dom', 'preact-compat')
 }

--- a/packages/next-preact/index.js
+++ b/packages/next-preact/index.js
@@ -12,6 +12,8 @@ module.exports = (nextConfig = {}) => {
       }
 
       config.resolve.alias = Object.assign({}, config.resolve.alias, {
+        'react/cjs/react.production.min.js': 'preact-compat/dist/preact-compat.min.js',
+        'react-dom/cjs/react-dom.production.min.js': 'preact-compat/dist/preact-compat.min.js',
         react: 'preact-compat',
         'react-dom': 'preact-compat'
       })


### PR DESCRIPTION
Added additional aliases of the minified cjs versions of `react` and `react-dom` - it seems some modules require these directly and result in the error below. 

Not sure if this was the best way of doing this but it does resolve the issue here.

![image](https://user-images.githubusercontent.com/5347038/37101421-863739da-221d-11e8-9cc9-dde7af5d5167.png)
