### PR TITLE
allow extending bundle analyzer config

### DIFF
--- a/packages/next-bundle-analyzer/index.js
+++ b/packages/next-bundle-analyzer/index.js
@@ -8,16 +8,25 @@ module.exports = (nextConfig = {}) => {
       }
 
       const { analyzeServer, analyzeBrowser } = nextConfig
+      const {
+        bundleAnalyzerConfig: { browser = {}, server = {} } = {}
+      } = nextConfig
       const { isServer } = options
 
       if ((isServer && analyzeServer) || (!isServer && analyzeBrowser)) {
         const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer')
         config.plugins.push(
-          new BundleAnalyzerPlugin({
-            analyzerMode: 'server',
-            analyzerPort: isServer ? 8888 : 8889,
-            openAnalyzer: true
-          })
+          new BundleAnalyzerPlugin(
+            Object.assign(
+              {},
+              {
+                analyzerMode: 'server',
+                analyzerPort: isServer ? 8888 : 8889,
+                openAnalyzer: true
+              },
+              isServer ? server : browser
+            )
+          )
         )
       }
 

--- a/packages/next-bundle-analyzer/readme.md
+++ b/packages/next-bundle-analyzer/readme.md
@@ -24,7 +24,17 @@ const { BundleAnalyzerPlugin } = require("webpack-bundle-analyzer");
 
 module.exports = withBundleAnalyzer({
   analyzeServer: ["server", "both"].includes(process.env.BUNDLE_ANALYZE),
-  analyzeBrowser: ["browser", "both"].includes(process.env.BUNDLE_ANALYZE)
+  analyzeBrowser: ["browser", "both"].includes(process.env.BUNDLE_ANALYZE),
+  bundleAnalyzerConfig: {
+    server: {
+      analyzerMode: 'static',
+      reportFilename: '../../bundles/server.html'
+    },
+    browser: {
+      analyzerMode: 'static',
+      reportFilename: '../bundles/client.html'
+    }
+  }
 });
 ```
 


### PR DESCRIPTION
We would like to have this reported automatically to a static bucket somewhere so we can have it on a dashboard.

I thought the easiest way would be to allow extending the analyzer config, that could help other report in whatever way they want with the analyzer.