### PR TITLE
Improve cssLoaderOptions by controlling fileName

### DIFF
--- a/packages/next-css/index.js
+++ b/packages/next-css/index.js
@@ -21,7 +21,7 @@ module.exports = (nextConfig = {}) => {
 
       if (!extractCSSPlugin) {
         extractCSSPlugin = new ExtractTextPlugin({
-          filename: 'static/style.css'
+          filename: 'static/' + (cssLoaderOptions.fileName ? cssLoaderOptions.fileName : 'style.css')
         })
         config.plugins.push(extractCSSPlugin)
         options.extractCSSPlugin = extractCSSPlugin


### PR DESCRIPTION
We need to control the output fileName of the final css in our project. Would be totally nice if this could be an optional parameter of `cssLoaderOptions`.

We tried to override the whole section handling the `ExtractTextPlugin` from the outside which works - except for one part of the existing code:

```javascript
if (!isServer) {
  config = commonsChunkConfig(config)
}
```

This part is crucial - and cannot be achieved from the outside in `next.config.js` - or we would need to import the "commonsChunkConfig" function of this plugin too and it gets messy...

What do you think about this improvement?