### PR TITLE
Add typescripts baseUrl setting to webpacks module resolver

### DIFF
--- a/packages/next-typescript/package.json
+++ b/packages/next-typescript/package.json
@@ -8,6 +8,7 @@
     "ts-loader": "^3.3.1"
   },
   "peerDependencies": {
+    "find-up": "^2.1.0",
     "typescript": "^2.6.2"
   }
 }

--- a/packages/next-typescript/package.json
+++ b/packages/next-typescript/package.json
@@ -5,10 +5,10 @@
   "license": "MIT",
   "repository": "zeit/next-plugins",
   "dependencies": {
+    "find-up": "^2.1.0",
     "ts-loader": "^3.3.1"
   },
   "peerDependencies": {
-    "find-up": "^2.1.0",
     "typescript": "^2.6.2"
   }
 }


### PR DESCRIPTION
### `@zeit/next-typescript`
When taking advantage of TypeScripts `baseUrl` setting to get rid of these long relative imports, you'll currently get an error because only typescript knows about it but webpack/babel doesn't know how to resolve the path.

The changes in this PR fix this by adding the `baseUrl` of the `tsconfig.json` to webpacks [`resolve.modules`](https://webpack.js.org/configuration/resolve/#resolve-modules) setting so the paths get resolved exactly the same.

As the [usage instructions in @zeit/next-typescripts readme](https://github.com/zeit/next-plugins/blob/master/packages/next-typescript/readme.md#usage) also suggest setting the `baseUrl` setting, I think this should be the default behavior (editors also autoimport with this value).

There is no additional configuration needed.

```typescript
// pages/user/settings/privacy/index.js

// without baseUrl:
import Button from '../../../../components/Button';

// with baseUrl set to . as in the usage instruction in the readme:
import Button from 'components/Button';
```