### PR TITLE
Added 'next-inferno' to community plugins

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -12,11 +12,12 @@
 
 ## Community made plugins
 
-- [next-offline](https://github.com/hanford/next-offline)
-- [next-plugin-graphql](https://github.com/lfades/next-plugin-graphql)
 - [next-awesome-typescript](https://github.com/saitonakamura/next-awesome-typescript)
-- [next-pino](https://github.com/khaeransori/next-pino)
 - [next-images](https://github.com/arefaslani/next-images)
+- [next-inferno](https://github.com/queses/next-inferno)
+- [next-offline](https://github.com/hanford/next-offline)
+- [next-pino](https://github.com/khaeransori/next-pino)
+- [next-plugin-graphql](https://github.com/lfades/next-plugin-graphql)
 
 ## Adding a plugin
 


### PR DESCRIPTION
This PR contains similar to `next-preact` plugin for page rendering with very fast [Inferno](https://infernojs.org/) library. Now as community plugin 👌 
Also I set community plugin in alphabetical order.