### PR TITLE
 Fixed typo in 'next-typescript' plugin's readme

### DIFF
--- a/packages/next-typescript/readme.md
+++ b/packages/next-typescript/readme.md
@@ -74,7 +74,7 @@ module.exports = withTypescript({
 
 ### Type checking
 
-If your IDE or code editor don't provide satisfying TypeScript support, or you want to see error list in console output, you can use ``fork-ts-checker-webpack-plugin`](https://github.com/Realytics/fork-ts-checker-webpack-plugin). It will not increase compile time because it forks type checking in a separate process
+If your IDE or code editor don't provide satisfying TypeScript support, or you want to see error list in console output, you can use [`fork-ts-checker-webpack-plugin`](https://github.com/Realytics/fork-ts-checker-webpack-plugin). It will not increase compile time because it forks type checking in a separate process
 
 ```js
 // next.config.js

--- a/packages/next-typescript/readme.md
+++ b/packages/next-typescript/readme.md
@@ -71,3 +71,22 @@ module.exports = withTypescript({
   }
 })
 ```
+
+### Type checking
+
+If your IDE or code editor don't provide satisfying TypeScript support, or you want to see error list in console output, you can use ``fork-ts-checker-webpack-plugin`](https://github.com/Realytics/fork-ts-checker-webpack-plugin). It will not increase compile time because it forks type checking in a separate process
+
+```js
+// next.config.js
+const withTypescript = require("@zeit/next-typescript")
+var ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
+
+module.exports = withTypescript({
+  webpack(config, options) {
+    // Do not run type checking twice:
+    if (options.isServer) config.plugins.push(new ForkTsCheckerWebpackPlugin())
+    
+    return config
+  }
+})
+```


### PR DESCRIPTION
Sorry, I made markdown syntax error in 'next-typescript' plugin's readme. This PR fixes it