### PR TITLE
Add missing port

### DIFF
--- a/packages/next-preact/readme.md
+++ b/packages/next-preact/readme.md
@@ -34,6 +34,7 @@ const next = require('next')
 
 
 const app = next({ dev: process.env.NODE_ENV !== 'production' })
+const port = process.env.PORT || 3000
 const handle = app.getRequestHandler()
 
 app.prepare()


### PR DESCRIPTION
Fix example server.js syntax error because of missing port variable definition