### PR TITLE
Add next-runtime-dotenv community plugin

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -22,6 +22,7 @@
 - [next-pino](https://github.com/khaeransori/next-pino)
 - [next-plugin-graphql](https://github.com/lfades/next-plugin-graphql)
 - [next-testcafe-build](https://github.com/formatlos/next-testcafe-build)
+- [next-runtime-dotenv](https://github.com/tusbar/next-runtime-dotenv)
 
 ## Adding a plugin
 


### PR DESCRIPTION
This plugin allows exposing environment variables (using dotenv) to Next.js’s runtime configuration.

I made an example showing how it can be used: https://github.com/tusbar/next-runtime-dotenv/tree/master/example

Configuration is straightforward:

```js
const nextRuntimeDotenv = require('next-runtime-dotenv')

const withConfig = nextRuntimeDotenv({
  // path: '.env'

  public: [
    'PUBLIC_VALUE'
  ],

  server: [
    'SERVER_ONLY'
  ]
})

module.exports = withConfig()
```

And it is used as such:

```js
import getConfig from 'next/config'

const {
  publicRuntimeConfig: {PUBLIC_VALUE},
  serverRuntimeConfig: {SERVER_ONLY}
} = getConfig()

export default () => {
  console.log('PUBLIC_VALUE', PUBLIC_VALUE)
  console.log('SERVER_ONLY', SERVER_ONLY)

  return (
    <div>
      Open your console!
    </div>
  )
}
```