### PR TITLE
Adds `next-mdxc` to official plugin list on readme.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -10,6 +10,7 @@
 - [@zeit/next-typescript](./packages/next-typescript)
 - [@zeit/next-bundle-analyzer](./packages/next-bundle-analyzer)
 - [@zeit/next-source-maps](./packages/next-source-maps)
+- [@zeit/next-mdxc](./packages/next-mdxc)
 
 ## Community made plugins
 


### PR DESCRIPTION
I was *really* wanting to add [mdxc](https://github.com/jamesknelson/mdxc) to [next.js](https://github.com/zeit/next.js). I checked [next-plugins](https://github.com/zeit/next-plugins) first, but didn't see it listed on the readme. 

I started implementing it myself only to discover [an official next-mdx on npm](https://www.npmjs.com/package/@zeit/next-mdxc). 

I figured it might be worth the add to the official plugin list. 😉 