### PR TITLE
Skip pre-processing on vendor css assets and add ability to selectively skip pre-processing

### DIFF
--- a/packages/next-css/css-loader-config.js
+++ b/packages/next-css/css-loader-config.js
@@ -3,14 +3,14 @@ const findUp = require('find-up')
 module.exports = (
   config,
   extractPlugin,
-  { cssModules = false, cssLoaderOptions = {}, dev, isServer, loaders = [] }
+  { cssModules = false, cssLoaderOptions = {}, dev, isServer, loaders = [], usePostcss = false }
 ) => {
   const postcssConfig = findUp.sync('postcss.config.js', {
     cwd: config.context
   })
   let postcssLoader
 
-  if (postcssConfig) {
+  if (usePostcss && postcssConfig) {
     postcssLoader = {
       loader: 'postcss-loader',
       options: {
@@ -29,7 +29,7 @@ module.exports = (
         modules: cssModules,
         minimize: !dev,
         sourceMap: dev,
-        importLoaders: loaders.length + (postcssLoader ? 1 : 0)
+        importLoaders: usePostcss && (loaders.length + (postcssLoader ? 1 : 0))
       },
       cssLoaderOptions
     )

--- a/packages/next-css/index.js
+++ b/packages/next-css/index.js
@@ -30,16 +30,36 @@ module.exports = (nextConfig = {}) => {
         }
       }
 
-      options.defaultLoaders.css = cssLoaderConfig(config, extractCSSPlugin, {
-        cssModules,
+      options.defaultLoaders.rawCss = cssLoaderConfig(config, extractCSSPlugin, {
+        cssModules: false,
         cssLoaderOptions,
         dev,
         isServer
       })
 
+      options.defaultLoaders.css = cssLoaderConfig(config, extractCSSPlugin, {
+        cssModules,
+        cssLoaderOptions,
+        dev,
+        isServer,
+        usePostcss: true
+      })
+
       config.module.rules.push({
         test: /\.css$/,
-        use: options.defaultLoaders.css
+        oneOf: [
+          {
+            include: /node_modules/,
+            use: options.defaultLoaders.rawCss
+          },
+          {
+            resourceQuery: /raw/,
+            use: options.defaultLoaders.rawCss
+          },
+          {
+            use: options.defaultLoaders.css
+          }
+        ]
       })
 
       if (typeof nextConfig.webpack === 'function') {

--- a/packages/next-css/readme.md
+++ b/packages/next-css/readme.md
@@ -158,6 +158,17 @@ export default class MyDocument extends Document {
 }
 ```
 
+### Without CSS pre-processing
+
+Sometimes you don't want any css pre-processing at all, such as perhaps global styling or vendored assets. You can skip any pre-processing, css modules, etc. at all, by appending `?raw` to any css import. These assets will still be extracted into `_next/static/styles.css`.
+
+CSS imported from npm modules in `/node_modules/` automatically skip any pre-processing.
+
+Create a page file `pages/index.js`
+
+```js
+import "./global.css?raw"
+```
 
 ### PostCSS plugins
 


### PR DESCRIPTION
This PR adds support for skipping pre-processing selectively on css imports and automatically skips pre-processing on `node_modules` css imports. This solves https://github.com/zeit/next-plugins/issues/110. If you use css modules, postcss tries to process any vendor css you have and so it never renders it correctly since it converts all the class names to local ones with a has at the end.

This PR still copies the contents of non pre-processed css into `_next/static/style.css` though.

css in `node_modules` shouldn't be processed at all by default in my opinion. I'd assume that any vendor css is already in the form it's meant to be used in. This allows you to selectively skip pre-processing in your own import statements with:

```
import "some_file.css?raw"
```