### PR TITLE
Make it explicit where to put next.config.js

### DIFF
--- a/packages/next-css/readme.md
+++ b/packages/next-css/readme.md
@@ -41,7 +41,7 @@ export default class MyDocument extends Document {
 
 ### Without CSS modules
 
-Create a `next.config.js` in your project
+Create a `next.config.js` in the root of your project (next to pages/ and package.json)
 
 ```js
 // next.config.js


### PR DESCRIPTION
It wasn't clear where to put this config file, so I suggest making it explicit by copying the language from the main repo.