### PR TITLE
Compile TypeScript with Babel

### DIFF
--- a/packages/next-typescript/index.js
+++ b/packages/next-typescript/index.js
@@ -35,23 +35,15 @@ module.exports = (nextConfig = {}) => {
         })
       }
 
+      if (!defaultLoaders.babel.options.babelrc) {
+        defaultLoaders.babel.options.presets.unshift("@babel/preset-typescript")
+      }
+
       config.module.rules.push({
         test: /\.(ts|tsx)$/,
         include: [dir],
         exclude: /node_modules/,
-        use: [
-          defaultLoaders.babel,
-          {
-            loader: 'ts-loader',
-            options: Object.assign(
-              {},
-              {
-                transpileOnly: true
-              },
-              nextConfig.typescriptLoaderOptions
-            )
-          }
-        ]
+        use: defaultLoaders.babel
       })
 
       if (typeof nextConfig.webpack === 'function') {

--- a/packages/next-typescript/package.json
+++ b/packages/next-typescript/package.json
@@ -5,9 +5,10 @@
   "license": "MIT",
   "repository": "zeit/next-plugins",
   "dependencies": {
-    "ts-loader": "3.3.1"
+    "@babel/preset-typescript": "^7.0.0-beta.46"
   },
   "peerDependencies": {
-    "typescript": "^2.6.2"
+    "typescript": "^2.6.2",
+    "next": ">= 6"
   }
 }

--- a/packages/next-typescript/readme.md
+++ b/packages/next-typescript/readme.md
@@ -65,6 +65,19 @@ module.exports = withTypescript({
 })
 ```
 
+### Note when using a custom `.babelrc`
+
+If you're using a custom `.babelrc` file, you need to add `@babel/preset-typescript` to it
+
+```json
+{
+  "presets": [
+    "@babel/preset-typescript",
+    "next/babel"
+  ]
+}
+```
+
 ### Type checking
 
 If your IDE or code editor don't provide satisfying TypeScript support, or you want to see error list in console output, you can use [`fork-ts-checker-webpack-plugin`](https://github.com/Realytics/fork-ts-checker-webpack-plugin). It will not increase compile time because it forks type checking in a separate process

--- a/packages/next-typescript/readme.md
+++ b/packages/next-typescript/readme.md
@@ -61,9 +61,6 @@ const withTypescript = require('@zeit/next-typescript')
 module.exports = withTypescript({
   webpack(config, options) {
     return config
-  },
-  typescriptLoaderOptions: {
-    transpileOnly: false
   }
 })
 ```


### PR DESCRIPTION
Since next.js v6 uses Babel 7, TypeScript can be compiled without `ts-loader`. Compilation should be considerably faster this way, especially in larger apps. Type checking still works with [`fork-ts-checker-webpack-plugin`](https://github.com/Realytics/fork-ts-checker-webpack-plugin).

I've tested that this works but I'm not sure adding `@babel/preset-typescript` to `defaultLoaders.babel.options.presets` is safe to do. But it's the most convenient way without requiring users to add a custom `.babelrc` file.

This is a breaking change and should be a major bump (or rather minor to `0.2.0`), since it depends on next@6 and removes `typescriptLoaderOptions`.