### PR TITLE
Add link to next-without-jest

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -25,6 +25,7 @@
 - [next-testcafe-build](https://github.com/formatlos/next-testcafe-build)
 - [next-runtime-dotenv](https://github.com/tusbar/next-runtime-dotenv)
 - [next-progressbar](https://github.com/lucleray/next-progressbar)
+- [next-without-jest](https://github.com/stipsan/next-without-jest)
 
 ## Adding a plugin
 


### PR DESCRIPTION
I made a small zero-config plugin that excludes test related files from the build. Makes it a little easier to use Jest and Next.js in the same project 😄 