### PR TITLE
Add pageExtensions to next-mdx

### DIFF
--- a/packages/next-mdx/index.js
+++ b/packages/next-mdx/index.js
@@ -1,4 +1,12 @@
 module.exports = (pluginOptions = {}) => (nextConfig = {}) => {
+  if (!nextConfig.pageExtensions) {
+    nextConfig.pageExtensions = ['jsx', 'js']
+  }
+
+  if (nextConfig.pageExtensions.indexOf('mdx') === -1) {
+    nextConfig.pageExtensions.unshift('mdx')
+  }
+
   return Object.assign({}, nextConfig, {
     webpack(config, options) {
       if (!options.defaultLoaders) {


### PR DESCRIPTION
So I can create file `pages/hello.mdx` that would be published as http://localhost:3000/hello.

Inspired by similar setup in next-typescript: https://github.com/zeit/next-plugins/commit/e3080bc4fc884c92ceac4bd3aff5d72a20b42ea4