### PR TITLE
Make MDX plugin extension configurable

### DIFF
--- a/packages/next-mdx/index.js
+++ b/packages/next-mdx/index.js
@@ -1,4 +1,6 @@
 module.exports = (pluginOptions = {}) => (nextConfig = {}) => {
+  const extension = pluginOptions.extension || /\.mdx$/
+
   return Object.assign({}, nextConfig, {
     webpack(config, options) {
       if (!options.defaultLoaders) {
@@ -8,7 +10,7 @@ module.exports = (pluginOptions = {}) => (nextConfig = {}) => {
       }
 
       config.module.rules.push({
-        test: /\.mdx$/,
+        test: extension,
         use: [
           options.defaultLoaders.babel,
           {

--- a/packages/next-mdx/readme.md
+++ b/packages/next-mdx/readme.md
@@ -1,6 +1,6 @@
 # Next.js + MDX
 
-Use [mdx](https://github.com/mdx-js/mdx) with [Next.js](https://github.com/zeit/next.js)
+Use [MDX](https://github.com/mdx-js/mdx) with [Next.js](https://github.com/zeit/next.js)
 
 ## Installation
 
@@ -31,7 +31,7 @@ Optionally you can provide [MDX options](https://github.com/mdx-js/mdx#options):
 const withMDX = require('@zeit/next-mdx')({
   options: {
     mdPlugins: [
-      
+
     ],
     hastPlugins: [
 
@@ -51,4 +51,14 @@ module.exports = withMDX({
     return config
   }
 })
+```
+
+Optionally you can match other file extensions for MDX compilation, by default only `.mdx` is supported
+
+```js
+// next.config.js
+const withMDX = require('@zeit/next-mdx')({
+  extension: /\.mdx?$/
+})
+module.exports = withMDX()
 ```


### PR DESCRIPTION
This allows users to customize their MDX extension if
they'd like. For example, one can customize the extension
matcher to be /\.mdx?$/ to support both .md and .mdx file
extensions.