### PR TITLE
[next-css] Provides Manifest Hash in Production

### DIFF
--- a/packages/next-css/index.js
+++ b/packages/next-css/index.js
@@ -21,7 +21,7 @@ module.exports = (nextConfig = {}) => {
 
       if (!extractCSSPlugin) {
         extractCSSPlugin = new ExtractTextPlugin({
-          filename: 'static/style.css'
+          filename: dev ? 'static/style.css' : 'static/style-[contenthash:12].css'
         })
         config.plugins.push(extractCSSPlugin)
         options.extractCSSPlugin = extractCSSPlugin

--- a/packages/next-css/readme.md
+++ b/packages/next-css/readme.md
@@ -195,6 +195,35 @@ Create a CSS file `style.css` the CSS here is using the css-variables postcss pl
 
 When `postcss.config.js` is not found `postcss-loader` will not be added and will not cause overhead.
 
+### Leverage long-term browser caching of style.css in production
+
+For production builds, the hashed filename is available in `this.props.buildManifest.css`, so the `_document.js` could be changed to:
+
+```js
+// ./pages/_document.js
+import Document, { Head, Main, NextScript } from 'next/document'
+
+export default class MyDocument extends Document {
+  render() {
+    const { buildManifest } = this.props;
+    return (
+      <html>
+        <Head>
+          {buildManifest.css.map(assetPath => (
+            // this will work in both development and production
+            <link key={assetPath} rel="stylesheet" href={`/_next/${assetPath}`} />
+          ))}
+        </Head>
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </html>
+    )
+  }
+}
+```
+
 ### Configuring Next.js
 
 Optionally you can add your custom Next.js configuration as parameter

--- a/packages/next-css/readme.md
+++ b/packages/next-css/readme.md
@@ -140,28 +140,6 @@ Your exported HTML will then reflect locally scoped CSS class names.
 
 For a list of supported options, [refer to the webpack `css-loader` README](https://github.com/webpack-contrib/css-loader#options).
 
-```js
-// ./pages/_document.js
-import Document, { Head, Main, NextScript } from 'next/document'
-
-export default class MyDocument extends Document {
-  render() {
-    return (
-      <html>
-        <Head>
-          <link rel="stylesheet" href="/_next/static/style.css" />
-        </Head>
-        <body>
-          <Main />
-          <NextScript />
-        </body>
-      </html>
-    )
-  }
-}
-```
-
-
 ### PostCSS plugins
 
 Create a `next.config.js` in your project

--- a/packages/next-css/readme.md
+++ b/packages/next-css/readme.md
@@ -197,7 +197,7 @@ When `postcss.config.js` is not found `postcss-loader` will not be added and wil
 
 ### Leverage long-term browser caching of style.css in production
 
-For production builds, the hashed filename is available in `this.props.buildManifest.css`, so the `_document.js` could be changed to:
+The `Document` component has access to assets manifest via its `this.props.buildManifest`. In order to leverage long-term caching (filename with content hash) for the compiled stylesheet, you can include it in `_document.js`.
 
 ```js
 // ./pages/_document.js
@@ -210,7 +210,6 @@ export default class MyDocument extends Document {
       <html>
         <Head>
           {buildManifest.css.map(assetPath => (
-            // this will work in both development and production
             <link key={assetPath} rel="stylesheet" href={`/_next/${assetPath}`} />
           ))}
         </Head>

--- a/packages/next-css/readme.md
+++ b/packages/next-css/readme.md
@@ -16,7 +16,7 @@ yarn add @zeit/next-css
 
 ## Usage
 
-The stylesheet is compiled to `.next/static/style.css`. You have to include it into the page using a custom [`_document.js`](https://github.com/zeit/next.js#custom-document). The file will be served from `/_next/static/style.css`
+The extracted stylesheet is generated to `.next/static` folder. You have to include it into the page using a custom [`_document.js`](https://github.com/zeit/next.js#custom-document).
 
 ```js
 // ./pages/_document.js
@@ -24,10 +24,13 @@ import Document, { Head, Main, NextScript } from 'next/document'
 
 export default class MyDocument extends Document {
   render() {
+    const { buildManifest: { css } } = this.props;
     return (
       <html>
         <Head>
-          <link rel="stylesheet" href="/_next/static/style.css" />
+          {css.map(filepath => (
+            <link key={filepath} rel="stylesheet" href={`/_next/${filepath}`} />
+          ))}
         </Head>
         <body>
           <Main />
@@ -194,34 +197,6 @@ Create a CSS file `style.css` the CSS here is using the css-variables postcss pl
 ```
 
 When `postcss.config.js` is not found `postcss-loader` will not be added and will not cause overhead.
-
-### Leverage long-term browser caching of style.css in production
-
-The `Document` component has access to assets manifest via its `this.props.buildManifest`. In order to leverage long-term caching (filename with content hash) for the compiled stylesheet, you can include it in `_document.js`.
-
-```js
-// ./pages/_document.js
-import Document, { Head, Main, NextScript } from 'next/document'
-
-export default class MyDocument extends Document {
-  render() {
-    const { buildManifest } = this.props;
-    return (
-      <html>
-        <Head>
-          {buildManifest.css.map(assetPath => (
-            <link key={assetPath} rel="stylesheet" href={`/_next/${assetPath}`} />
-          ))}
-        </Head>
-        <body>
-          <Main />
-          <NextScript />
-        </body>
-      </html>
-    )
-  }
-}
-```
 
 ### Configuring Next.js
 


### PR DESCRIPTION
In production, extract style.css with content hash to leverage long-term browser caching.

As https://github.com/zeit/next.js/pull/4119 landed, now we have access to webpack manifest in `_document.js` via `this.props.buildManifest`. This PR enables build with contenthash in `!dev`.

Related to issue: https://github.com/zeit/next-plugins/issues/11

Test was successful on my personal site (inspect the network tab): https://thanik.me