### PR TITLE
Fix typo in next-sass locally scoped css example

### DIFF
--- a/packages/next-sass/readme.md
+++ b/packages/next-sass/readme.md
@@ -111,7 +111,7 @@ module.exports = withSass({
 })
 ```
 
-Create a CSS file `styles.css`
+Create a SCSS file `style.scss`
 
 ```css
 .example {
@@ -122,7 +122,7 @@ Create a CSS file `styles.css`
 Create a page file `pages/index.js` that imports your stylesheet and uses the hashed class name from the stylesheet
 
 ```js
-import css from "../style.css"
+import css from "../style.scss"
 
 const Component = props => {
   return (


### PR DESCRIPTION
The example in the section [With CSS modules and options](https://github.com/zeit/next-plugins/tree/master/packages/next-sass#with-css-modules-and-options) doesn't work for me.

A stylesheet `styles.css` is created that then gets referenced as `style.css`.
Despite the mismatch of the filename (trailing `s`), this also throws an error that a loader is missing for css files for me.
As this package is a loader for sass files, the file ending should probably be `.scss` or similar.

Using my proposed changes fixes the example for me.

---
Also, I felt a little overwhelmed by adding something to `next.config.js`, as I was just getting started with Next.js.
I'd suggest adding information about where that files resides (next to `package.json`) or referencing the [section from the global readme](https://github.com/zeit/next.js/#custom-configuration).