### PR TITLE
Allow for postcss-loader options to be passed

### DIFF
--- a/packages/next-css/css-loader-config.js
+++ b/packages/next-css/css-loader-config.js
@@ -3,7 +3,7 @@ const findUp = require('find-up')
 module.exports = (
   config,
   extractPlugin,
-  { cssModules = false, cssLoaderOptions = {}, dev, isServer, loaders = [] }
+  { cssModules = false, cssLoaderOptions = {}, postcssLoaderOptions = {}, dev, isServer, loaders = [] }
 ) => {
   const postcssConfig = findUp.sync('postcss.config.js', {
     cwd: config.context
@@ -11,13 +11,20 @@ module.exports = (
   let postcssLoader
 
   if (postcssConfig) {
+    //Copy the postcss-loader config options first.
+    postcssOptionsConfig = Object.assign(
+      {},
+      postcssLoaderOptions.config,
+      { path: postcssConfig }
+    )
+
     postcssLoader = {
       loader: 'postcss-loader',
-      options: {
-        config: {
-          path: postcssConfig
-        }
-      }
+      options: Object.assign(
+        {},
+        postcssLoaderOptions,
+        { config: postcssOptionsConfig }
+      )
     }
   }
 

--- a/packages/next-css/index.js
+++ b/packages/next-css/index.js
@@ -12,7 +12,7 @@ module.exports = (nextConfig = {}) => {
       }
 
       const { dev, isServer } = options
-      const { cssModules, cssLoaderOptions } = nextConfig
+      const { cssModules, cssLoaderOptions, postcssLoaderOptions } = nextConfig
       // Support the user providing their own instance of ExtractTextPlugin.
       // If extractCSSPlugin is not defined we pass the same instance of ExtractTextPlugin to all css related modules
       // So that they compile to the same file in production
@@ -33,6 +33,7 @@ module.exports = (nextConfig = {}) => {
       options.defaultLoaders.css = cssLoaderConfig(config, extractCSSPlugin, {
         cssModules,
         cssLoaderOptions,
+        postcssLoaderOptions,
         dev,
         isServer
       })

--- a/packages/next-css/readme.md
+++ b/packages/next-css/readme.md
@@ -195,6 +195,27 @@ Create a CSS file `style.css` the CSS here is using the css-variables postcss pl
 
 When `postcss.config.js` is not found `postcss-loader` will not be added and will not cause overhead.
 
+You can also pass a list of options to the `postcss-loader` by passing an object called `postcssLoaderOptions`.
+
+For example, to pass theme env variables to postcss-loader, you can write:
+
+```js
+// next.config.js
+const withCSS = require('@zeit/next-css')
+module.exports = withCSS({
+  postcssLoaderOptions: {
+    parser: true,
+    config: {
+      ctx: {
+        theme: JSON.stringify(process.env.REACT_APP_THEME)
+      }
+    }
+  }
+})
+```
+
+
+
 ### Configuring Next.js
 
 Optionally you can add your custom Next.js configuration as parameter

--- a/packages/next-less/index.js
+++ b/packages/next-less/index.js
@@ -15,6 +15,7 @@ module.exports = (nextConfig = {}) => {
       const {
         cssModules,
         cssLoaderOptions,
+        postcssLoaderOptions,
         lessLoaderOptions = {}
       } = nextConfig
       // Support the user providing their own instance of ExtractTextPlugin.
@@ -37,6 +38,7 @@ module.exports = (nextConfig = {}) => {
       options.defaultLoaders.less = cssLoaderConfig(config, extractCSSPlugin, {
         cssModules,
         cssLoaderOptions,
+        postcssLoaderOptions,
         dev,
         isServer,
         loaders: [

--- a/packages/next-less/readme.md
+++ b/packages/next-less/readme.md
@@ -196,6 +196,26 @@ Create a CSS file `styles.scss` the CSS here is using the css-variables postcss 
 
 When `postcss.config.js` is not found `postcss-loader` will not be added and will not cause overhead.
 
+You can also pass a list of options to the `postcss-loader` by passing an object called `postcssLoaderOptions`.
+
+For example, to pass theme env variables to postcss-loader, you can write:
+
+```js
+// next.config.js
+const withLess = require('@zeit/next-less')
+module.exports = withLess({
+  postcssLoaderOptions: {
+    parser: true,
+    config: {
+      ctx: {
+        theme: JSON.stringify(process.env.REACT_APP_THEME)
+      }
+    }
+  }
+})
+```
+
+
 ### Configuring Next.js
 
 Optionally you can add your custom Next.js configuration as parameter

--- a/packages/next-sass/index.js
+++ b/packages/next-sass/index.js
@@ -15,6 +15,7 @@ module.exports = (nextConfig = {}) => {
       const {
         cssModules,
         cssLoaderOptions,
+        postcssLoaderOptions,
         sassLoaderOptions = {}
       } = nextConfig
       // Support the user providing their own instance of ExtractTextPlugin.
@@ -37,6 +38,7 @@ module.exports = (nextConfig = {}) => {
       options.defaultLoaders.sass = cssLoaderConfig(config, extractCSSPlugin, {
         cssModules,
         cssLoaderOptions,
+        postcssLoaderOptions,
         dev,
         isServer,
         loaders: [

--- a/packages/next-sass/readme.md
+++ b/packages/next-sass/readme.md
@@ -210,6 +210,26 @@ Create a CSS file `styles.scss` the CSS here is using the css-variables postcss 
 
 When `postcss.config.js` is not found `postcss-loader` will not be added and will not cause overhead.
 
+You can also pass a list of options to the `postcss-loader` by passing an object called `postcssLoaderOptions`.
+
+For example, to pass theme env variables to postcss-loader, you can write:
+
+```js
+// next.config.js
+const withSass = require('@zeit/next-sass')
+module.exports = withSass({
+  postcssLoaderOptions: {
+    parser: true,
+    config: {
+      ctx: {
+        theme: JSON.stringify(process.env.REACT_APP_THEME)
+      }
+    }
+  }
+})
+```
+
+
 ### Configuring Next.js
 
 Optionally you can add your custom Next.js configuration as parameter

--- a/packages/next-stylus/index.js
+++ b/packages/next-stylus/index.js
@@ -15,6 +15,7 @@ module.exports = (nextConfig = {}) => {
       const {
         cssModules,
         cssLoaderOptions,
+        postcssLoaderOptions,
         stylusLoaderOptions = {}
       } = nextConfig
       // Support the user providing their own instance of ExtractTextPlugin.
@@ -37,6 +38,7 @@ module.exports = (nextConfig = {}) => {
       options.defaultLoaders.stylus = cssLoaderConfig(config, extractCSSPlugin, {
         cssModules,
         cssLoaderOptions,
+        postcssLoaderOptions,
         dev,
         isServer,
         loaders: [

--- a/packages/next-stylus/readme.md
+++ b/packages/next-stylus/readme.md
@@ -215,6 +215,25 @@ Create a Stylus file `styles.styl` the Stylus here is using the css-variables po
   color var(--some-color)
 
 ```
+You can also pass a list of options to the `postcss-loader` by passing an object called `postcssLoaderOptions`.
+
+For example, to pass theme env variables to postcss-loader, you can write:
+
+```js
+// next.config.js
+const withStylus = require('@zeit/next-stylus')
+module.exports = withStylus({
+  postcssLoaderOptions: {
+    parser: true,
+    config: {
+      ctx: {
+        theme: JSON.stringify(process.env.REACT_APP_THEME)
+      }
+    }
+  }
+})
+```
+
 
 ### Configuring Next.js
 


### PR DESCRIPTION
Make it possible to pass postcss-loader options like config (path, context), parser, etc.
This can be useful, for example, to pass theme env variables to postcss-loader.

next.config.js would look like:
```
module.exports = withCSS({
  postcssLoaderOptions: {
    parser: true,
    config: {
      ctx: {
        theme: JSON.stringify(process.env.REACT_APP_THEME)
      }
    }
  }
})
```