### PR TITLE
Removed webpack bundle analyzer require from readme

### DIFF
--- a/packages/next-bundle-analyzer/readme.md
+++ b/packages/next-bundle-analyzer/readme.md
@@ -20,7 +20,6 @@ Create a next.config.js (and make sure you have next-css set up)
 
 ```js
 const withBundleAnalyzer = require("@zeit/next-bundle-analyzer");
-const { BundleAnalyzerPlugin } = require("webpack-bundle-analyzer");
 
 module.exports = withBundleAnalyzer({
   analyzeServer: ["server", "both"].includes(process.env.BUNDLE_ANALYZE),


### PR DESCRIPTION
This line wasn't necessary for setting up this plugin. In fact, if you're requiring it here, you're likely rolling this plugin's behavior yourself.