### PR TITLE
feat: use css of typescript

### DIFF
--- a/packages/next-css/css-loader-config.js
+++ b/packages/next-css/css-loader-config.js
@@ -28,8 +28,18 @@ module.exports = (
     }
   }
 
+  const tsconfig = findUp.sync('tsconfig.json', {
+    cwd: config.context
+  })
+  let loaderName;
+  if (tsconfig) {
+    loaderName = isServer ? 'css-loader/locals' : 'typings-for-css-modules-loader';
+  } else {
+    loaderName = isServer ? 'css-loader/locals' : 'css-loader';
+  }
+
   const cssLoader = {
-    loader: isServer ? 'css-loader/locals' : 'css-loader',
+    loader: loaderName,
     options: Object.assign(
       {},
       {

--- a/packages/next-css/package.json
+++ b/packages/next-css/package.json
@@ -10,7 +10,8 @@
     "extracted-loader": "1.0.4",
     "find-up": "2.1.0",
     "ignore-loader": "0.1.2",
-    "postcss-loader": "2.0.10"
+    "postcss-loader": "2.0.10",
+    "typings-for-css-modules-loader": "^1.7.0"
   },
   "devDependencies": {
     "webpack": "^3.10.0"


### PR DESCRIPTION
## What's issue?

If use typescript on product, get error: `Cannot find module './file.css'`

### Resolve

If [typings-for-css-modules-loader](https://github.com/Jimdo/typings-for-css-modules-loader) use, this issue is resolved.
Because `typings-for-css-modules-loader` automatically generate `.css.d.ts`.
