### PR TITLE
Add next-purgecss

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -25,6 +25,7 @@
 - [next-testcafe-build](https://github.com/formatlos/next-testcafe-build)
 - [next-runtime-dotenv](https://github.com/tusbar/next-runtime-dotenv)
 - [next-progressbar](https://github.com/lucleray/next-progressbar)
+- [next-purgecss](https://github.com/lucleray/next-purgecss)
 
 ## Adding a plugin
 


### PR DESCRIPTION
(next-purgecss)[https://github.com/lucleray/next-purgecss] can be used to remove unused styles.

It's mostly useful when using an external css library (like tachyons for example).