### PR TITLE
Fixes an error when using postcss without a postcssLoaderOptions

### DIFF
--- a/packages/next-css/css-loader-config.js
+++ b/packages/next-css/css-loader-config.js
@@ -12,7 +12,7 @@ module.exports = (
     cssLoaderOptions = {},
     dev,
     isServer,
-    postcssLoaderOptions,
+    postcssLoaderOptions = {},
     loaders = []
   }
 ) => {


### PR DESCRIPTION
When using postcss without a postcssLoaderOptions in next.config.js, on the canary branch, it throws a typeError (Cannot read property 'config' of undefined).

This (simple) PR provides a default value for the postcssLoaderOptions and fixes the problem.