### PR TITLE
Upgrade Babel Typescript preset

### DIFF
--- a/packages/next-typescript/package.json
+++ b/packages/next-typescript/package.json
@@ -5,6 +5,6 @@
   "license": "MIT",
   "repository": "zeit/next-plugins",
   "dependencies": {
-    "@babel/preset-typescript": "7.0.0-beta.42"
+    "@babel/preset-typescript": "7.0.0-beta.55"
   }
 }


### PR DESCRIPTION
This fixes the issue that JSX generics don't work (a new TS 2.9 feature), see #227.