### PR TITLE
Update readme.md

### DIFF
--- a/packages/next-sass/readme.md
+++ b/packages/next-sass/readme.md
@@ -126,7 +126,7 @@ import css from "../style.scss"
 
 const Component = props => {
   return (
-    <div className={css.backdrop}>
+    <div className={css.example}>
       ...
     </div>
   )


### PR DESCRIPTION
Hello,

Here is a small fix for a typo `css.backdrop` => `css.example` as there is no `backdrop` class defined

Please let me know if this makes sense.
Thanks