### PR TITLE
Add next-plugin-transpile-modules community plugin

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -28,6 +28,7 @@
 - [next-runtime-dotenv](https://github.com/tusbar/next-runtime-dotenv)
 - [next-progressbar](https://github.com/lucleray/next-progressbar)
 - [next-purgecss](https://github.com/lucleray/next-purgecss)
+- [next-plugin-transpile-modules](https://github.com/KeitIG/next-plugin-transpile-modules)
 
 ## Adding a plugin
 


### PR DESCRIPTION
> Transpile untranspiled modules from your node_modules. Makes it easy to have local libraries and keep a slick, manageable dev experience.