### PR TITLE
[@zeit/next-typescript] Updated recommended tsconfig in README

### DIFF
--- a/packages/next-typescript/readme.md
+++ b/packages/next-typescript/readme.md
@@ -41,7 +41,6 @@ Create a `tsconfig.json` in your project
 
 ```json
 {
-  "compileOnSave": false,
   "compilerOptions": {
     "target": "esnext",
     "module": "esnext",

--- a/packages/next-typescript/readme.md
+++ b/packages/next-typescript/readme.md
@@ -46,20 +46,18 @@ Create a `tsconfig.json` in your project
     "target": "esnext",
     "module": "esnext",
     "jsx": "preserve",
-    "allowJs": true,
+    "lib": ["dom", "es2017"],
+    "baseUrl": ".",
     "moduleResolution": "node",
-    "allowSyntheticDefaultImports": true,
+    "allowJs": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "removeComments": false,
     "preserveConstEnums": true,
-    "sourceMap": true,
-    "skipLibCheck": true,
-    "baseUrl": ".",
-    "lib": [
-      "dom",
-      "es2016"
-    ]
+    "sourceMap": true
   }
 }
 ```


### PR DESCRIPTION
This changes the recommended tsconfig settings in the next-typescript
README. I'll also include this in the Next.js TS examples shortly.

- Enable `noEmit` to perform type-checking without transpiling
- `compileOnSave` is not required now that `noEmit` is required
- Upgraded `lib` from `es2016` to `es2017`