### PR TITLE
[@zeit/next-typescript] esModuleInterop -> allowSyntheticDefaultImports

### DIFF
--- a/packages/next-typescript/readme.md
+++ b/packages/next-typescript/readme.md
@@ -50,7 +50,7 @@ Create a `tsconfig.json` in your project
     "moduleResolution": "node",
     "allowJs": true,
     "noEmit": true,
-    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
     "skipLibCheck": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,


### PR DESCRIPTION
Hey, it's me again 🙃

As mentioned on https://github.com/zeit/next.js/pull/5267, this fixes `esModuleInterop` as discovered when updating the examples on the main repo.