### PR TITLE
Fix preset-typescript to use default options for TSX files

### DIFF
--- a/packages/next-typescript/babel.js
+++ b/packages/next-typescript/babel.js
@@ -1,5 +1,8 @@
 module.exports = () => {
   return {
-    presets: [require('@babel/preset-typescript')]
+    presets: [require('@babel/preset-typescript'), { 
+      "isTSX": true,
+      "allExtensions": true
+    }]
   }
 }


### PR DESCRIPTION
`@babel/preset-typescript` requires the following options to be set to handle TSX files:

```
{ 
  "isTSX": true,
  "allExtensions": true
}
```

https://babeljs.io/docs/en/next/babel-preset-typescript.html#istsx

> I'm not 100% sure whether this is the right approach, we may wish to instruct users to place this configuration in their `.babelrc` instead?