### PR TITLE
Don't pass removed `minimize` option to CSS Loader

### DIFF
--- a/packages/next-css/css-loader-config.js
+++ b/packages/next-css/css-loader-config.js
@@ -73,7 +73,6 @@ module.exports = (
       {},
       {
         modules: cssModules,
-        minimize: !dev,
         sourceMap: dev,
         importLoaders: loaders.length + (postcssLoader ? 1 : 0)
       },


### PR DESCRIPTION
The option has been removed in version 1.0, see https://github.com/webpack-contrib/css-loader/pull/742/commits/965068d568cc4862c0a00b263fc5fea6840f72d2.

Fixes #286.