### PR TITLE
Enable sourcemaps in dev for both postcss and sass

### DIFF
--- a/packages/next-css/css-loader-config.js
+++ b/packages/next-css/css-loader-config.js
@@ -61,9 +61,15 @@ module.exports = (
 
     postcssLoader = {
       loader: 'postcss-loader',
-      options: Object.assign({}, postcssLoaderOptions, {
-        config: postcssOptionsConfig
-      })
+      options: Object.assign(
+        {
+          sourceMap: dev
+        },
+        postcssLoaderOptions,
+        {
+          config: postcssOptionsConfig
+        }
+      )
     }
   }
 

--- a/packages/next-sass/index.js
+++ b/packages/next-sass/index.js
@@ -27,7 +27,12 @@ module.exports = (nextConfig = {}) => {
         loaders: [
           {
             loader: 'sass-loader',
-            options: sassLoaderOptions
+            options: Object.assign(
+              {
+                sourceMap: dev
+              },
+              sassLoaderOptions
+            )
           }
         ]
       })


### PR DESCRIPTION
This enables sourcemaps for both postcss and sass in development (just like they are enabled for css in development mode).