### PR TITLE
fix workers plugin for nextjs@7 by handling global `self`

### DIFF
--- a/packages/next-workers/index.js
+++ b/packages/next-workers/index.js
@@ -7,7 +7,7 @@ module.exports = (nextConfig = {}) => {
         )
       }
 
-      config.module.rules.push({
+      config.module.rules.push(
         test: /\.worker\.js$/,
         loader: 'worker-loader',
         options: nextConfig.workerLoaderOptions || {
@@ -15,6 +15,9 @@ module.exports = (nextConfig = {}) => {
           publicPath: '/_next/'
         }
       })
+
+      // Overcome webpack referencing `window` in chunks
+      config.output.globalObject = `(typeof self !== 'undefined' ? self : this)`
 
       if (typeof nextConfig.webpack === 'function') {
         return nextConfig.webpack(config, options)

--- a/packages/next-workers/index.js
+++ b/packages/next-workers/index.js
@@ -7,7 +7,7 @@ module.exports = (nextConfig = {}) => {
         )
       }
 
-      config.module.rules.push(
+      config.module.rules.push({
         test: /\.worker\.js$/,
         loader: 'worker-loader',
         options: nextConfig.workerLoaderOptions || {

--- a/packages/next-workers/readme.md
+++ b/packages/next-workers/readme.md
@@ -29,7 +29,7 @@ Optionally you can add your custom Next.js configuration as parameter
 ```js
 // next.config.js
 const withWorkers = require('@zeit/next-workers')
-module.exports = withWorkers(
+module.exports = withWorkers({
   webpack(config, options) {
     return config
   }


### PR DESCRIPTION
This addresses this comment that the workers plugin is no longer working in next@7:
https://github.com/zeit/next-plugins/pull/218#issuecomment-428805318

This is rooted in this issue, in which the fix is to configure webpack to handle non-window global objects in the client in order for it to internally handle references to the global:
https://github.com/webpack/webpack/issues/6642

This next plugin is meant to handle files written as WebWorkers, in which `window` as the global is undefined (in lieu of `self`), so I've decided to explicitly fallback to `self` as the global object.

In addition, I've fixed a typo where a bracket was missing in the README.