### PR TITLE
Fix syntax error in next-workers README example

### DIFF
--- a/packages/next-workers/readme.md
+++ b/packages/next-workers/readme.md
@@ -29,7 +29,7 @@ Optionally you can add your custom Next.js configuration as parameter
 ```js
 // next.config.js
 const withWorkers = require('@zeit/next-workers')
-module.exports = withWorkers(
+module.exports = withWorkers({
   webpack(config, options) {
     return config
   }


### PR DESCRIPTION
I was browsing through the documentation for next-workers and got confused by a code example. I believe the intention was to pass an object to `withWorkers` but a leading `{` was missing.