### PR TITLE
Added queries for files import without post-processing

### DIFF
--- a/packages/next-css/css-loader-config.js
+++ b/packages/next-css/css-loader-config.js
@@ -1,4 +1,4 @@
-const MiniCssExtractPlugin = require('mini-css-extract-plugin')
+const ExtractCssChunks = require('extract-css-chunks-webpack-plugin')
 const findUp = require('find-up')
 
 const fileExtensions = new Set()
@@ -14,7 +14,7 @@ module.exports = (
     isServer,
     postcssLoaderOptions = {},
     loaders = [],
-    disablePostcss = false,
+    disablePostcss = false
   }
 ) => {
   // We have to keep a list of extensions for the splitchunk config
@@ -33,7 +33,7 @@ module.exports = (
 
   if (!isServer && !extractCssInitialized) {
     config.plugins.push(
-      new MiniCssExtractPlugin({
+      new ExtractCssChunks({
         // Options similar to the same options in webpackOptions.output
         // both options are optional
         filename: dev
@@ -94,7 +94,7 @@ module.exports = (
 
   return [
     !isServer && dev && 'extracted-loader',
-    !isServer && MiniCssExtractPlugin.loader,
+    !isServer && ExtractCssChunks.loader,
     cssLoader,
     !disablePostcss && postcssLoader,
     ...loaders

--- a/packages/next-css/css-loader-config.js
+++ b/packages/next-css/css-loader-config.js
@@ -1,4 +1,4 @@
-const ExtractCssChunks = require('extract-css-chunks-webpack-plugin')
+const MiniCssExtractPlugin = require('mini-css-extract-plugin')
 const findUp = require('find-up')
 
 const fileExtensions = new Set()
@@ -13,7 +13,8 @@ module.exports = (
     dev,
     isServer,
     postcssLoaderOptions = {},
-    loaders = []
+    loaders = [],
+    disablePostcss = false,
   }
 ) => {
   // We have to keep a list of extensions for the splitchunk config
@@ -32,7 +33,7 @@ module.exports = (
 
   if (!isServer && !extractCssInitialized) {
     config.plugins.push(
-      new ExtractCssChunks({
+      new MiniCssExtractPlugin({
         // Options similar to the same options in webpackOptions.output
         // both options are optional
         filename: dev
@@ -40,9 +41,7 @@ module.exports = (
           : 'static/css/[name].[contenthash:8].css',
         chunkFilename: dev
           ? 'static/css/[name].chunk.css'
-          : 'static/css/[name].[contenthash:8].chunk.css',
-        orderWarning: false,
-        reloadAll: true
+          : 'static/css/[name].[contenthash:8].chunk.css'
       })
     )
     extractCssInitialized = true
@@ -95,9 +94,9 @@ module.exports = (
 
   return [
     !isServer && dev && 'extracted-loader',
-    !isServer && ExtractCssChunks.loader,
+    !isServer && MiniCssExtractPlugin.loader,
     cssLoader,
-    postcssLoader,
+    !disablePostcss && postcssLoader,
     ...loaders
   ].filter(Boolean)
 }

--- a/packages/next-css/index.js
+++ b/packages/next-css/index.js
@@ -12,18 +12,35 @@ module.exports = (nextConfig = {}) => {
       const { dev, isServer } = options
       const { cssModules, cssLoaderOptions, postcssLoaderOptions } = nextConfig
 
-      options.defaultLoaders.css = cssLoaderConfig(config, {
-        extensions: ['css'],
+      const crateStyleConfig = (cssModules, disablePostcss) => cssLoaderConfig(config, {
         cssModules,
         cssLoaderOptions,
-        postcssLoaderOptions,
         dev,
-        isServer
-      })
+        isServer,
+        disablePostcss
+      });
+
+      options.defaultLoaders.css = crateStyleConfig(cssModules);
 
       config.module.rules.push({
         test: /\.css$/,
-        use: options.defaultLoaders.css
+        oneOf: [
+          {
+            resourceQuery: /CSSModulesDisbale/,
+            use: crateStyleConfig(false, true)
+          },
+          {
+            resourceQuery: /postCSSDisable/,
+            use: crateStyleConfig(true, false)
+          },
+          {
+            resourceQuery: /postCSSAndCSSModulesDisable/,
+            use: crateStyleConfig(false, true)
+          },
+          {
+            use: options.defaultLoaders.css
+          }
+        ]
       })
 
       if (typeof nextConfig.webpack === 'function') {

--- a/packages/next-css/package.json
+++ b/packages/next-css/package.json
@@ -6,10 +6,10 @@
   "repository": "zeit/next-plugins",
   "dependencies": {
     "css-loader": "1.0.0",
+    "extract-css-chunks-webpack-plugin": "^3.2.1",
     "extracted-loader": "1.0.4",
     "find-up": "2.1.0",
     "ignore-loader": "0.1.2",
-    "mini-css-extract-plugin": "^0.4.4",
     "postcss-loader": "3.0.0"
   },
   "devDependencies": {

--- a/packages/next-css/package.json
+++ b/packages/next-css/package.json
@@ -6,10 +6,10 @@
   "repository": "zeit/next-plugins",
   "dependencies": {
     "css-loader": "1.0.0",
-    "extract-css-chunks-webpack-plugin": "^3.2.0",
     "extracted-loader": "1.0.4",
     "find-up": "2.1.0",
     "ignore-loader": "0.1.2",
+    "mini-css-extract-plugin": "^0.4.4",
     "postcss-loader": "3.0.0"
   },
   "devDependencies": {

--- a/packages/next-css/readme.md
+++ b/packages/next-css/readme.md
@@ -119,6 +119,21 @@ Your exported HTML will then reflect locally scoped CSS class names.
 
 For a list of supported options, [refer to the webpack `css-loader` README](https://github.com/webpack-contrib/css-loader#options).
 
+
+### Import CSS files without CSS modules or post-css
+
+#### Without CSS modules
+
+```import 'antd/dist/antd.css?CSSModulesDisbale'```
+
+#### Without post-css
+
+```import 'antd/dist/antd.css?postCSSDisable'```
+
+#### Without CSS modules and post-css
+
+```import 'antd/dist/antd.css?postCSSAndCSSModulesDisable'```
+
 ### PostCSS plugins
 
 Create a `next.config.js` in your project

--- a/yarn.lock
+++ b/yarn.lock
@@ -2841,10 +2841,10 @@ extglob@^2.0.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
-extract-css-chunks-webpack-plugin@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/extract-css-chunks-webpack-plugin/-/extract-css-chunks-webpack-plugin-3.2.0.tgz#7200caa68ddc73b9e8c822683b6e7e4968fe9c5e"
-  integrity sha512-d+CcBBfOi1NnAhA9RMG5SxuXNLMZ6/BeDK27jvQ5O9WfV48CersET1RNiLC5VRHCFHH3nA13ybhg9oz+Td9Npg==
+extract-css-chunks-webpack-plugin@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/extract-css-chunks-webpack-plugin/-/extract-css-chunks-webpack-plugin-3.2.1.tgz#d8ee9cacbfe6339522fced41efc7976f4f77243a"
+  integrity sha512-6ev0KuxCrffDLjycjG46OcVyCGZNfL+M7MySWHW/1M/wRCV/DTZnNAnWa8f7ti/kU4OnkyTfv8geAUWutAjd3w==
   dependencies:
     loader-utils "^1.1.0"
     lodash "^4.17.5"


### PR DESCRIPTION
@timneutkens @arunoda @jamesgorrie @rauchg 
Hi! Great job with plugins!
I thought that it'd be nice to have an option to import CSS files without post-css or CSS modules post-processing.
I think it's useful for situations when some CSS framework (like ant-design) is used and it makes you import their CSS bundle.  
It'll look like that:
#### Without CSS modules
 ```import 'antd/dist/antd.css?CSSModulesDisbale'```
 #### Without post-css
 ```import 'antd/dist/antd.css?postCSSDisable'```
 #### Without CSS modules and post-css
 ```import 'antd/dist/antd.css?postCSSAndCSSModulesDisable'```