### PR TITLE
Update next-mdx to match other plugins' interface

### DIFF
--- a/packages/next-mdx/index.js
+++ b/packages/next-mdx/index.js
@@ -1,5 +1,15 @@
-module.exports = (pluginOptions = {}) => (nextConfig = {}) => {
-  const extension = pluginOptions.extension || /\.mdx$/
+module.exports = (nextConfig = {}) => {
+  if (!nextConfig.pageExtensions) {
+    nextConfig.pageExtensions = ['jsx', 'js']
+  }
+
+  if (nextConfig.pageExtensions.indexOf('mdx') === -1) {
+    nextConfig.pageExtensions.unshift('mdx')
+  }
+
+  if (nextConfig.pageExtensions.indexOf('md') === -1) {
+    nextConfig.pageExtensions.unshift('md')
+  }
 
   return Object.assign({}, nextConfig, {
     webpack(config, options) {
@@ -9,13 +19,17 @@ module.exports = (pluginOptions = {}) => (nextConfig = {}) => {
         )
       }
 
+      const {mdxLoaderOptions = {}} = nextConfig
+
+      config.resolve.extensions.push('.md', '.mdx')
+
       config.module.rules.push({
-        test: extension,
+        test: /\.mdx?$/,
         use: [
           options.defaultLoaders.babel,
           {
             loader: '@mdx-js/loader',
-            options: pluginOptions.options
+            options: mdxLoaderOptions
           }
         ]
       })

--- a/packages/next-mdx/readme.md
+++ b/packages/next-mdx/readme.md
@@ -20,7 +20,7 @@ Create a `next.config.js` in your project
 
 ```js
 // next.config.js
-const withMDX = require('@zeit/next-mdx')()
+const withMDX = require('@zeit/next-mdx')
 module.exports = withMDX()
 ```
 
@@ -28,8 +28,10 @@ Optionally you can provide [MDX options](https://github.com/mdx-js/mdx#options):
 
 ```js
 // next.config.js
-const withMDX = require('@zeit/next-mdx')({
-  options: {
+const withMDX = require('@zeit/next-mdx')
+
+module.exports = withMDX({
+  mdxLoaderOptions: {
     mdPlugins: [
 
     ],
@@ -38,14 +40,13 @@ const withMDX = require('@zeit/next-mdx')({
     ]
   }
 })
-module.exports = withMDX()
 ```
 
 Optionally you can add your custom Next.js configuration as parameter
 
 ```js
 // next.config.js
-const withMDX = require('@zeit/next-mdx')()
+const withMDX = require('@zeit/next-mdx')
 module.exports = withMDX({
   webpack(config, options) {
     return config
@@ -53,26 +54,4 @@ module.exports = withMDX({
 })
 ```
 
-Optionally you can match other file extensions for MDX compilation, by default only `.mdx` is supported
-
-```js
-// next.config.js
-const withMDX = require('@zeit/next-mdx')({
-  extension: /\.mdx?$/
-})
-module.exports = withMDX()
-```
-
-## Top level .mdx pages
-
-Define the `pagesExtensions` option to have Next.js handle `.mdx` files in the `pages` directory as pages:
-
-```js
-// next.config.js
-const withMDX = require('@zeit/next-mdx')({
-  extension: /\.mdx?$/
-})
-module.exports = withMDX({
-  pageExtensions: ['js', 'jsx', 'mdx']
-})
-```
+The supported file extensions are `.mdx` and `.md`.


### PR DESCRIPTION
This is a PR in response of #320.

The following changes are made:
  1. Remove `pluginOptions` currying in favour of specifying `nextConfig.mdxLoaderOptions`.
  2. Custom extensions via `pluginOptions.extension` are now impossible since `pluginOptions` is removed. The extensions are now limited to `.mdx` and `.md`.

The `README.md` file has been updated accordingly.

This commit is definitely breaking, but I don't know how to handle it. Is it possible to specify a deprecation warning or backward compatibility somewhere?