### PR TITLE
Fail on user importing CSS in _document.js, since it won’t be bundled

### DIFF
--- a/packages/next-css/index.js
+++ b/packages/next-css/index.js
@@ -23,6 +23,14 @@ module.exports = (nextConfig = {}) => {
 
       config.module.rules.push({
         test: /\.css$/,
+        issuer(issuer) {
+          if (issuer.match(/pages[\\/]_document\.js$/)) {
+            throw new Error(
+              'You can not import CSS files in pages/_document.js, use pages/_app.js instead.'
+            )
+          }
+          return true
+        },
         use: options.defaultLoaders.css
       })
 


### PR DESCRIPTION
As previously this would lead to confusion.