### PR TITLE
Upgrade @mdx-js/loader and @mdx-js/mdx to ^0.16.0

### DIFF
--- a/packages/next-mdx/package.json
+++ b/packages/next-mdx/package.json
@@ -5,10 +5,10 @@
   "license": "MIT",
   "repository": "zeit/next-plugins",
   "dependencies": {
-    "@mdx-js/loader": "^0.15.0"
+    "@mdx-js/loader": "^0.16.0"
   },
   "peerDependencies": {
-    "@mdx-js/mdx": "^0.15.0"
+    "@mdx-js/mdx": "^0.16.0"
   },
   "gitHead": "31e8978d07e5468f760a222a72d1e8f3f457e6ff"
 }

--- a/packages/next-mdx/package.json
+++ b/packages/next-mdx/package.json
@@ -4,11 +4,9 @@
   "main": "index.js",
   "license": "MIT",
   "repository": "zeit/next-plugins",
-  "dependencies": {
-    "@mdx-js/loader": "^0.16.0"
-  },
   "peerDependencies": {
-    "@mdx-js/mdx": "^0.16.0"
+    "@mdx-js/loader": ">=0.0.1",
+    "@mdx-js/mdx": ">=0.0.1"
   },
   "gitHead": "31e8978d07e5468f760a222a72d1e8f3f457e6ff"
 }

--- a/packages/next-mdx/readme.md
+++ b/packages/next-mdx/readme.md
@@ -5,13 +5,13 @@ Use [MDX](https://github.com/mdx-js/mdx) with [Next.js](https://github.com/zeit/
 ## Installation
 
 ```
-npm install --save @zeit/next-mdx @mdx-js/mdx
+npm install --save @zeit/next-mdx @mdx-js/loader @mdx-js/mdx
 ```
 
 or
 
 ```
-yarn add @zeit/next-mdx @mdx-js/mdx
+yarn add @zeit/next-mdx @mdx-js/loader @mdx-js/mdx
 ```
 
 ## Usage


### PR DESCRIPTION
This PR upgrades `@mdx-js/loader` and `@mdx-js/mdx` to their latest versions and closes https://github.com/zeit/next-plugins/issues/333.