### PR TITLE
Show how to match other file extensions

### DIFF
--- a/packages/next-mdx/readme.md
+++ b/packages/next-mdx/readme.md
@@ -58,7 +58,7 @@ Optionally you can match other file extensions for MDX compilation, by default o
 ```js
 // next.config.js
 const withMDX = require('@zeit/next-mdx')({
-  extension: /\.mdx?$/
+  extension: /\.(md|mdx)?$/
 })
 module.exports = withMDX()
 ```


### PR DESCRIPTION
The readme is lacking in that it talks about enabling other file extensions, but only shows how to keep the default. For people not used to regex it could be confusing how they can enable other extensions. 

Resolves #163 