### PR TITLE
Added next-css-unpluggable as a community plugin

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -31,6 +31,7 @@
 - [next-plugin-transpile-modules](https://github.com/KeitIG/next-plugin-transpile-modules)
 - [next-seo](https://github.com/garmeeh/next-seo)
 - [next-mdx-blog](https://github.com/hipstersmoothie/next-mdx-blog)
+- [next-css-unpluggable](https://github.com/Uncleseneca/next-css-unpluggable)
 
 ## Adding a plugin
 


### PR DESCRIPTION
Hi!
I added a link to a fork of next-css with which we can disable CSS modules and postCSS using queries in imports [next-css-unpluggable](https://github.com/Uncleseneca/next-css-unpluggable) 

It's mainly used to import CSS files from CSS-frameworks or libraries, when we don't need our classes to be scoped.

Also it addresses a number of issues:

- #319 
- #301 
- #273 

I opened a PR #322 but it wasn't merged because of its binding to webpack, but I hope that a mention in unofficial plugins list will help to close quite a lot of issues :smiley: 