### PR TITLE
Use css-loader 2.x

### DIFF
--- a/packages/next-css/css-loader-config.js
+++ b/packages/next-css/css-loader-config.js
@@ -1,4 +1,4 @@
-const MiniCssExtractPlugin = require("mini-css-extract-plugin")
+const ExtractCssChunks = require("extract-css-chunks-webpack-plugin")
 const findUp = require('find-up')
 
 const fileExtensions = new Set()
@@ -32,7 +32,7 @@ module.exports = (
 
   if (!isServer && !extractCssInitialized) {
     config.plugins.push(
-      new MiniCssExtractPlugin({
+      new ExtractCssChunks({
         // Options similar to the same options in webpackOptions.output
         // both options are optional
         filename: dev
@@ -41,6 +41,7 @@ module.exports = (
         chunkFilename: dev
           ? 'static/chunks/[name].chunk.css'
           : 'static/chunks/[name].[contenthash:8].chunk.css',
+        hot: dev
       })
     )
     extractCssInitialized = true
@@ -106,8 +107,7 @@ module.exports = (
   }
 
   return [
-    !isServer && dev && 'extracted-loader',
-    !isServer && MiniCssExtractPlugin.loader,
+    !isServer && ExtractCssChunks.loader,
     cssLoader,
     postcssLoader,
     ...loaders

--- a/packages/next-css/css-loader-config.js
+++ b/packages/next-css/css-loader-config.js
@@ -1,4 +1,4 @@
-const ExtractCssChunks = require("extract-css-chunks-webpack-plugin")
+const ExtractCssChunks = require('extract-css-chunks-webpack-plugin')
 const findUp = require('find-up')
 
 const fileExtensions = new Set()

--- a/packages/next-css/css-loader-config.js
+++ b/packages/next-css/css-loader-config.js
@@ -1,5 +1,6 @@
 const ExtractCssChunks = require('extract-css-chunks-webpack-plugin')
 const findUp = require('find-up')
+const OptimizeCssAssetsWebpackPlugin = require('optimize-css-assets-webpack-plugin')
 
 const fileExtensions = new Set()
 let extractCssInitialized = false
@@ -51,7 +52,7 @@ module.exports = (
     if (!Array.isArray(config.optimization.minimizer)) {
       config.optimization.minimizer = []
     }
-    const OptimizeCssAssetsWebpackPlugin = require('optimize-css-assets-webpack-plugin')
+
     config.optimization.minimizer.push(
       new OptimizeCssAssetsWebpackPlugin({
         cssProcessorOptions: {
@@ -61,17 +62,17 @@ module.exports = (
     )
   }
 
-  const postcssConfig = findUp.sync('postcss.config.js', {
+  const postcssConfigPath = findUp.sync('postcss.config.js', {
     cwd: config.context
   })
   let postcssLoader
 
-  if (postcssConfig) {
+  if (postcssConfigPath) {
     // Copy the postcss-loader config options first.
     const postcssOptionsConfig = Object.assign(
       {},
       postcssLoaderOptions.config,
-      { path: postcssConfig }
+      { path: postcssConfigPath }
     )
 
     postcssLoader = {

--- a/packages/next-css/package.json
+++ b/packages/next-css/package.json
@@ -5,16 +5,16 @@
   "license": "MIT",
   "repository": "zeit/next-plugins",
   "dependencies": {
-    "css-loader": "1.0.0",
-    "extract-css-chunks-webpack-plugin": "^3.2.0",
-    "extracted-loader": "1.0.4",
-    "find-up": "2.1.0",
+    "css-loader": "2.0.0",
+    "mini-css-extract-plugin": "^0.5.0",
+    "extracted-loader": "1.0.7",
+    "find-up": "3.0.0",
     "ignore-loader": "0.1.2",
     "optimize-css-assets-webpack-plugin": "^5.0.1",
     "postcss-loader": "3.0.0"
   },
   "devDependencies": {
-    "webpack": "^4.16.3"
+    "webpack": "^4.26.0"
   },
   "gitHead": "31e8978d07e5468f760a222a72d1e8f3f457e6ff"
 }

--- a/packages/next-css/package.json
+++ b/packages/next-css/package.json
@@ -5,12 +5,12 @@
   "license": "MIT",
   "repository": "zeit/next-plugins",
   "dependencies": {
-    "css-loader": "2.0.0",
+    "css-loader": "~2.0.1",
     "extract-css-chunks-webpack-plugin": "^3.2.1",
-    "find-up": "3.0.0",
-    "ignore-loader": "0.1.2",
+    "find-up": "~3.0.0",
+    "ignore-loader": "~0.1.2",
     "optimize-css-assets-webpack-plugin": "^5.0.1",
-    "postcss-loader": "3.0.0"
+    "postcss-loader": "~3.0.0"
   },
   "devDependencies": {
     "webpack": "^4.26.0"

--- a/packages/next-css/package.json
+++ b/packages/next-css/package.json
@@ -6,8 +6,7 @@
   "repository": "zeit/next-plugins",
   "dependencies": {
     "css-loader": "2.0.0",
-    "mini-css-extract-plugin": "^0.5.0",
-    "extracted-loader": "1.0.7",
+    "extract-css-chunks-webpack-plugin": "^3.2.1",
     "find-up": "3.0.0",
     "ignore-loader": "0.1.2",
     "optimize-css-assets-webpack-plugin": "^5.0.1",

--- a/packages/next-css/package.json
+++ b/packages/next-css/package.json
@@ -5,15 +5,15 @@
   "license": "MIT",
   "repository": "zeit/next-plugins",
   "dependencies": {
-    "css-loader": "~2.0.1",
-    "extract-css-chunks-webpack-plugin": "^3.2.1",
-    "find-up": "~3.0.0",
+    "css-loader": "^2.1.0",
+    "extract-css-chunks-webpack-plugin": "^3.3.2",
+    "find-up": "^3.0.0",
     "ignore-loader": "~0.1.2",
     "optimize-css-assets-webpack-plugin": "^5.0.1",
-    "postcss-loader": "~3.0.0"
+    "postcss-loader": "^3.0.0"
   },
   "devDependencies": {
-    "webpack": "^4.26.0"
+    "webpack": "^4.28.3"
   },
   "gitHead": "31e8978d07e5468f760a222a72d1e8f3f457e6ff"
 }

--- a/packages/next-css/package.json
+++ b/packages/next-css/package.json
@@ -13,7 +13,7 @@
     "postcss-loader": "^3.0.0"
   },
   "devDependencies": {
-    "webpack": "^4.28.3"
+    "webpack": "^4.29.5"
   },
   "gitHead": "31e8978d07e5468f760a222a72d1e8f3f457e6ff"
 }


### PR DESCRIPTION
Yesterday was released css-loader 2.0 which use postcss 7 and and many changes to enhance performance.

Removed extracted-loader because forcing hot reload in extract-css-chunks-webpack-plugin works same.