### PR TITLE
bump mdx dependencies

### DIFF
--- a/packages/next-mdx/package.json
+++ b/packages/next-mdx/package.json
@@ -5,10 +5,10 @@
   "license": "MIT",
   "repository": "zeit/next-plugins",
   "dependencies": {
-    "@mdx-js/loader": "^0.15.0"
+    "@mdx-js/loader": "^0.16.0"
   },
   "peerDependencies": {
-    "@mdx-js/mdx": "^0.15.0"
+    "@mdx-js/mdx": "^0.16.0"
   },
   "gitHead": "31e8978d07e5468f760a222a72d1e8f3f457e6ff"
 }


### PR DESCRIPTION
I'm experiencing `React does not recognize the metaString prop on a DOM element` issue which seem to be resolved in v0.16.0