### PR TITLE
fix(next-css): prioritize styles over commons cache group

### DIFF
--- a/packages/next-css/css-loader-config.js
+++ b/packages/next-css/css-loader-config.js
@@ -26,6 +26,7 @@ module.exports = (
       name: 'styles',
       test: new RegExp(`\\.+(${[...fileExtensions].join('|')})$`),
       chunks: 'all',
+      priority: 1,
       enforce: true
     }
   }


### PR DESCRIPTION
**Current behaviour**
Any styles loaded in `_app.js` will be grouped into `styles` cache group.

**Expected behaviour**
Since, `App` is shared across pages, any styles loaded in `_app.js` should be grouped into `commons` cache group.

**Proposed solution**
This PR basically "reverts" to next 6 behaviour, resulting in a single CSS file instead of having two CSS files.