### PR TITLE
Remove baseUrl config option.

### DIFF
--- a/packages/next-typescript/readme.md
+++ b/packages/next-typescript/readme.md
@@ -44,7 +44,6 @@ Create a `tsconfig.json` in your project
   "compilerOptions": {
     "allowJs": true,
     "allowSyntheticDefaultImports": true,
-    "baseUrl": ".",
     "jsx": "preserve",
     "lib": ["dom", "es2017"],
     "module": "esnext",


### PR DESCRIPTION
The example `tsconfig.json` specifies the option: `"baseUrl": ".",`

This has two negative effects:
- TypeScript allows paths such as `import Component from "components/Component"` but Babel does not by default. Typical NextJS configurations don't allow paths like this, so this results in uncaught runtime errors.
- Typescript / VSCode's auto-import will use these invalid paths instead of relative paths.