### PR TITLE
readme: make next.config.js work with now v2

### DIFF
--- a/packages/next-typescript/readme.md
+++ b/packages/next-typescript/readme.md
@@ -22,8 +22,22 @@ Create a `next.config.js` in your project
 
 ```js
 // next.config.js
-const withTypescript = require('@zeit/next-typescript')
-module.exports = withTypescript()
+const env =
+	process.env.NODE_ENV === 'development'
+		? {} // We're never in "production server" phase when in development mode
+		: !process.env.NOW_REGION
+		? require('next/constants') // Get values from `next` package when building locally
+		: require('next-server/constants') // Get values from `next-server` package when building on now v2
+
+module.exports = (phase, { defaultConfig }) => {
+	if (phase === env.PHASE_PRODUCTION_SERVER) {
+		// Config used to run in production.
+		return {}
+	}
+
+	const withTypescript = require('@zeit/next-typescript')
+	return withTypescript()
+}
 ```
 
 Create a `.babelrc` in your project


### PR DESCRIPTION
https://spectrum.chat/zeit/general/unable-to-import-module-now-launcher-error~2662f0ba-4186-402f-b1db-2e3c43d8689a