### PR TITLE
Fix typo in documentation import

### DIFF
--- a/packages/next-source-maps/readme.md
+++ b/packages/next-source-maps/readme.md
@@ -20,7 +20,7 @@ Create a next.config.js
 
 ```js
 // next.config.js
-const withSourceMaps = require('@zeit/next-source-maps')()
+const withSourceMaps = require('@zeit/next-source-maps')
 module.exports = withSourceMaps({
   webpack(config, options) {
     return config


### PR DESCRIPTION
The example, provided in the readme didn't work properly because of an extra `()` next to the import.