### PR TITLE
Add next-size community plugin

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -32,6 +32,7 @@
 - [next-seo](https://github.com/garmeeh/next-seo)
 - [next-mdx-blog](https://github.com/hipstersmoothie/next-mdx-blog)
 - [next-fonts](https://github.com/rohanray/next-fonts)
+- [next-size](https://github.com/lucleray/next-size)
 
 ## Adding a plugin
 


### PR DESCRIPTION
Since it's been removed from next (https://github.com/zeit/next.js/pull/6122), I think it makes sense to add next-size here as a community plugin.

I'll add a warning to the readme about the memory usage implications and I'll experiment some solutions to solve it in the community plugin itself, so next is safe 👌

some ideas :
- just showing the actual size and estimating the gzipped size (empirically)
- reading file on fs and calculating gzipped size (with a limit of nb of files)