### PR TITLE
next-mdx: add support for additional loaders

### DIFF
--- a/packages/next-mdx/index.js
+++ b/packages/next-mdx/index.js
@@ -1,5 +1,6 @@
 module.exports = (pluginOptions = {}) => (nextConfig = {}) => {
   const extension = pluginOptions.extension || /\.mdx$/
+  const additionalLoaders = pluginOptions.additionalLoaders || []
 
   return Object.assign({}, nextConfig, {
     webpack(config, options) {
@@ -17,7 +18,7 @@ module.exports = (pluginOptions = {}) => (nextConfig = {}) => {
             loader: '@mdx-js/loader',
             options: pluginOptions.options
           }
-        ]
+        ].concat(additionalLoaders)
       })
 
       if (typeof nextConfig.webpack === 'function') {


### PR DESCRIPTION
https://mdxjs.com/advanced/custom-loader

Should allow doing the following:

``` tsx
const withTypescript = require('@zeit/next-typescript')
const withMDX = require('@zeit/next-mdx')({
	extension: /\.mdx?$/,
	additionalLoaders: [
		async function(src) {
			const callback = this.async()
			const { content, body, header } = require('docmatter')(src)
			const meta = header ? JSON.parse(header) : {}
			const layout = require('path').join(__dirname, 'layouts', 'default')
			const code = [
				`import Layout from '${layout}'`,
				`export const meta = ${JSON.stringify(meta, null, '  ')}`,
				body || content,
				'export default ({ children }) => <Layout {...meta}>{children}</Layout>'
			].join('\n\n')
			return callback(null, code)
		}
	]
})
module.exports = withMDX(
	withTypescript({
		pageExtensions: ['js', 'jsx', 'ts', 'tsx', 'md', 'mdx'],
		target: 'serverless'
	})
)
```

Still testing this. Do not merge.