### PR TITLE
Postcss loader flexibility

### DIFF
--- a/packages/next-css/css-loader-config.js
+++ b/packages/next-css/css-loader-config.js
@@ -61,7 +61,7 @@ module.exports = (
   })
   let postcssLoader
 
-  if (postcssConfig) {
+  if (postcssConfig || postcssLoaderOptions) {
     // Copy the postcss-loader config options first.
     const postcssOptionsConfig = Object.assign(
       {},


### PR DESCRIPTION
In its current state, you can pass `postcssLoaderOptions` to the plugin, but if there is no `postcss.config.js` file in your root, they will do nothing. Simply adding a `postcss.config.js` file with `module.export = {}` will resolve this issue, but seems like a bit of a silly solution.

With this PR, whenever postcss loader options are passed through the plugin, they will apply with or without a `postcss.config.js` file 😁 