### PR TITLE
add next-css option to disable auto-adding postcss-loader

### DIFF
--- a/packages/next-css/css-loader-config.js
+++ b/packages/next-css/css-loader-config.js
@@ -13,6 +13,7 @@ module.exports = (
     dev,
     isServer,
     postcssLoaderOptions = {},
+    autoAddPostcss = true,
     loaders = []
   }
 ) => {
@@ -61,7 +62,7 @@ module.exports = (
   })
   let postcssLoader
 
-  if (postcssConfig) {
+  if (autoAddPostcss && postcssConfig) {
     // Copy the postcss-loader config options first.
     const postcssOptionsConfig = Object.assign(
       {},

--- a/packages/next-css/readme.md
+++ b/packages/next-css/readme.md
@@ -155,6 +155,17 @@ Create a CSS file `style.css` the CSS here is using the css-variables postcss pl
 
 When `postcss.config.js` is not found `postcss-loader` will not be added and will not cause overhead.
 
+You can disable automatic addition of the `postcss-loader` (depending on presence of `postcss.config.js`) by passing the `autoAddPostcss: false`:
+
+```js
+// next.config.js
+const withCSS = require('@zeit/next-css')
+module.exports = withCSS({
+  autoAddPostcss: false,
+})
+```
+
+
 You can also pass a list of options to the `postcss-loader` by passing an object called `postcssLoaderOptions`.
 
 For example, to pass theme env variables to postcss-loader, you can write:


### PR DESCRIPTION
I have a situation where I would like to run postcss from one of my custom webpack loaders, but don't want the Next.js CSS loader to invoke postcss. Right now, the Next.js CSS loader automatically adds the postcss loader if a `postcss.config.js` file is found.

This adds support for a `autoAddPostcss` option (defaulting to true, i.e. existing behavior), which can be set to false to avoid the "automatically add postcss loader" behaviour.