### PR TITLE
Throw error when sass files are imported into __document.js

### DIFF
--- a/packages/next-sass/index.js
+++ b/packages/next-sass/index.js
@@ -34,11 +34,15 @@ module.exports = (nextConfig = {}) => {
 
       config.module.rules.push(
         {
-          test: /\.scss$/,
-          use: options.defaultLoaders.sass
-        },
-        {
-          test: /\.sass$/,
+          test: /\.s[ac]ss$/,
+          issuer(issuer) {
+            if (issuer.match(/pages[\\/]_document\.js$/)) {
+              throw new Error(
+                'You can not import scss files in pages/_document.js, use pages/_app.js instead.'
+              )
+            }
+            return true
+          },
           use: options.defaultLoaders.sass
         }
       )


### PR DESCRIPTION
Fix for issue raised here https://github.com/zeit/next-plugins/issues/435