### PR TITLE
Bump `sass-loader^7.1.0`

### DIFF
--- a/packages/next-sass/package.json
+++ b/packages/next-sass/package.json
@@ -6,7 +6,7 @@
   "repository": "zeit/next-plugins",
   "dependencies": {
     "@zeit/next-css": "0.2.1-canary.4",
-    "sass-loader": "6.0.6"
+    "sass-loader": "^7.1.0"
   },
   "devDependencies": {
     "node-sass": "^4.7.2"


### PR DESCRIPTION
This will make it possible to use [dart-sass](https://github.com/sass/dart-sass). See webpack-contrib/sass-loader@bed9fb5799a90020d43f705ea405f85b368621d7