### PR TITLE
[next-bundle-analyzer] Fix browser report location in README example

### DIFF
--- a/packages/next-bundle-analyzer/readme.md
+++ b/packages/next-bundle-analyzer/readme.md
@@ -31,7 +31,7 @@ module.exports = withBundleAnalyzer({
     },
     browser: {
       analyzerMode: 'static',
-      reportFilename: '../bundles/client.html'
+      reportFilename: 'bundles/client.html'
     }
   }
 });


### PR DESCRIPTION
The server report is generated from ".next/server", but the browser report is generated from ".next". The README example was causing "bundles/client.html" to end up in "project_root/bundles" instead of "project_root/.next/bundles".