### PR TITLE
fix(next-css): remove `ignore-loader` block in css-loader-config

### DIFF
--- a/packages/next-css/css-loader-config.js
+++ b/packages/next-css/css-loader-config.js
@@ -97,11 +97,6 @@ module.exports = (
     )
   }
 
-  // When not using css modules we don't transpile on the server
-  if (isServer && !cssLoader.options.modules) {
-    return ['ignore-loader']
-  }
-
   // When on the server and using css modules we transpile the css
   if (isServer && cssLoader.options.modules) {
     return [cssLoader, postcssLoader, ...loaders].filter(Boolean)


### PR DESCRIPTION
This allows CSS to be transpiled on the server even if not using CSS modules, which allows stuff like `:export` blocks from ICSS to work.

I completely removed the block instead of adding an option to skip it, as I haven't experienced any adverse effects with removing it permanently in my testing, and I'm not sure what the original purpose of it was.

Fixes #445 