### PR TITLE
added parameters moduleExtension, moduleLoaderOptions to support .module extension

### DIFF
--- a/packages/next-css/index.js
+++ b/packages/next-css/index.js
@@ -10,11 +10,11 @@ module.exports = (nextConfig = {}) => {
       }
 
       const { dev, isServer } = options
-      const { cssModules, cssLoaderOptions, postcssLoaderOptions } = nextConfig
+      const { cssModules, cssLoaderOptions, postcssLoaderOptions, moduleExtension, moduleLoaderOptions } = nextConfig
 
       options.defaultLoaders.css = cssLoaderConfig(config, {
         extensions: ['css'],
-        cssModules,
+        cssModules: moduleExtension ? false : cssModules,
         cssLoaderOptions,
         postcssLoaderOptions,
         dev,
@@ -31,8 +31,34 @@ module.exports = (nextConfig = {}) => {
           }
           return true
         },
+        exclude: moduleExtension ? /\.module\.css$/ : /^$/,
         use: options.defaultLoaders.css
       })
+
+      if (moduleExtension) {
+        config.module.rules.push({
+          test: /\.module\.css$/,
+          issuer(issuer) {
+            if (issuer.match(/pages[\\/]_document\.js$/)) {
+              throw new Error(
+                'You can not import CSS files in pages/_document.js, use pages/_app.js instead.'
+              )
+            }
+            return true
+          },
+          use: cssLoaderConfig(config, {
+            extensions: ['css'],
+            cssModules: true,
+            cssLoaderOptions: moduleLoaderOptions || {
+              importLoaders: 1,
+              localIdentName: '[local]___[hash:base64:8]'
+            },
+            postcssLoaderOptions,
+            dev,
+            isServer
+          })
+        });
+      }
 
       if (typeof nextConfig.webpack === 'function') {
         return nextConfig.webpack(config, options)


### PR DESCRIPTION
Adds support for .module.css and .css as per https://facebook.github.io/create-react-app/docs/adding-a-css-modules-stylesheet

A lot of people are having this issue. I've tried to implement this with full backward compatibility.
If there are any changes required to the code, please reply back as I'm new to this.


Issue: #403 