### PR TITLE
Use devDependencies for node-sass in next-sass readme.md

### DIFF
--- a/packages/next-sass/readme.md
+++ b/packages/next-sass/readme.md
@@ -5,13 +5,15 @@ Import `.sass` or `.scss` files in your Next.js project
 ## Installation
 
 ```
-npm install --save @zeit/next-sass node-sass
+npm install @zeit/next-sass --save
+npm install node-sass --save-dev
 ```
 
 or
 
 ```
-yarn add @zeit/next-sass node-sass
+yarn add @zeit/next-sass
+yarn add node-sass --dev
 ```
 
 ## Usage


### PR DESCRIPTION
Doesn't seem to be a reason to save node-sass as a regular dependency