### PR TITLE
📝 documentation - more explicit wrapper examples

### DIFF
--- a/packages/next-css/readme.md
+++ b/packages/next-css/readme.md
@@ -26,7 +26,9 @@ Create a `next.config.js` in the root of your project (next to pages/ and packag
 ```js
 // next.config.js
 const withCSS = require('@zeit/next-css')
-module.exports = withCSS()
+module.exports = withCSS({
+  /* config options here */
+})
 ```
 
 Create a CSS file `style.css`
@@ -126,7 +128,9 @@ Create a `next.config.js` in your project
 ```js
 // next.config.js
 const withCSS = require('@zeit/next-css')
-module.exports = withCSS()
+module.exports = withCSS({
+  /* config options here */
+})
 ```
 
 Create a `postcss.config.js`

--- a/packages/next-less/readme.md
+++ b/packages/next-less/readme.md
@@ -26,7 +26,9 @@ Create a `next.config.js` in your project
 ```js
 // next.config.js
 const withLess = require('@zeit/next-less')
-module.exports = withLess()
+module.exports = withLess({
+  /* config options here */
+})
 ```
 
 Create a Less file `styles.less`
@@ -126,7 +128,9 @@ Create a `next.config.js` in your project
 ```js
 // next.config.js
 const withLess = require('@zeit/next-less')
-module.exports = withLess()
+module.exports = withLess({
+  /* config options here */
+})
 ```
 
 Create a `postcss.config.js`

--- a/packages/next-mdx/readme.md
+++ b/packages/next-mdx/readme.md
@@ -23,7 +23,9 @@ Create a `next.config.js` in your project
 ```js
 // next.config.js
 const withMDX = require('@zeit/next-mdx')()
-module.exports = withMDX()
+module.exports = withMDX({
+  /* config options here */
+})
 ```
 
 Optionally you can provide [MDX options](https://github.com/mdx-js/mdx#options):
@@ -40,7 +42,9 @@ const withMDX = require('@zeit/next-mdx')({
     ]
   }
 })
-module.exports = withMDX()
+module.exports = withMDX({
+  /* config options here */
+})
 ```
 
 Optionally you can add your custom Next.js configuration as parameter
@@ -62,7 +66,9 @@ Optionally you can match other file extensions for MDX compilation, by default o
 const withMDX = require('@zeit/next-mdx')({
   extension: /\.(md|mdx)$/
 })
-module.exports = withMDX()
+module.exports = withMDX({
+  /* config options here */
+})
 ```
 
 ## Top level .mdx pages

--- a/packages/next-preact/readme.md
+++ b/packages/next-preact/readme.md
@@ -21,7 +21,9 @@ Create a `next.config.js` in your project
 ```js
 // next.config.js
 const withPreact = require('@zeit/next-preact')
-module.exports = withPreact()
+module.exports = withPreact({
+  /* config options here */
+})
 ```
 
 Then create a `server.js`

--- a/packages/next-sass/readme.md
+++ b/packages/next-sass/readme.md
@@ -26,7 +26,9 @@ Create a `next.config.js` in your project
 ```js
 // next.config.js
 const withSass = require('@zeit/next-sass')
-module.exports = withSass()
+module.exports = withSass({
+  /* config options here */
+})
 ```
 
 Create a Sass file `styles.scss`
@@ -140,7 +142,9 @@ Create a `next.config.js` in your project
 ```js
 // next.config.js
 const withSass = require('@zeit/next-sass')
-module.exports = withSass()
+module.exports = withSass({
+  /* config options here */
+})
 ```
 
 Create a `postcss.config.js`

--- a/packages/next-stylus/readme.md
+++ b/packages/next-stylus/readme.md
@@ -26,7 +26,9 @@ Create a `next.config.js` in your project
 ```js
 // next.config.js
 const withStylus = require('@zeit/next-stylus')
-module.exports = withStylus()
+module.exports = withStylus({
+  /* config options here */
+})
 ```
 
 Create a Stylus file `styles.styl`

--- a/packages/next-typescript/readme.md
+++ b/packages/next-typescript/readme.md
@@ -23,7 +23,9 @@ Create a `next.config.js` in your project
 ```js
 // next.config.js
 const withTypescript = require('@zeit/next-typescript')
-module.exports = withTypescript()
+module.exports = withTypescript({
+  /* config options here */
+})
 ```
 
 Create a `.babelrc` in your project

--- a/packages/next-workers/readme.md
+++ b/packages/next-workers/readme.md
@@ -21,7 +21,9 @@ Create a `next.config.js` in your project
 ```js
 // next.config.js
 const withWorkers = require('@zeit/next-workers')
-module.exports = withWorkers()
+module.exports = withWorkers({
+  /* config options here */
+})
 ```
 
 Optionally you can add your custom Next.js configuration as parameter


### PR DESCRIPTION
This [tripped me up][tripped] while using [Next.js][next] for the first time.

I didn't understand that the `withSomething()` function had to wrap the configuration object.  
So I added an extra comment to each wrapper call to explicitly state that it should wrap the object.

```javascript
// next.config.js

module.exports = withSass({
  /* config options here */
})
```

[tripped]: https://twitter.com/bradgarropy/status/1135570827318050817
[next]: https://nextjs.org