### PR TITLE
Always use globalObject:self for Worker contexts

### DIFF
--- a/packages/next-workers/index.js
+++ b/packages/next-workers/index.js
@@ -17,7 +17,7 @@ module.exports = (nextConfig = {}) => {
       })
 
       // Overcome webpack referencing `window` in chunks
-      config.output.globalObject = `(typeof self !== 'undefined' ? self : this)`
+      config.output.globalObject = 'self'
 
       if (typeof nextConfig.webpack === 'function') {
         return nextConfig.webpack(config, options)


### PR DESCRIPTION
They all have it.