### PR TITLE
Bump preact to v10

### DIFF
--- a/packages/next-preact/alias.js
+++ b/packages/next-preact/alias.js
@@ -1,7 +1,6 @@
-const path = require('path')
 const moduleAlias = require('module-alias')
 
 module.exports = () => {
-  moduleAlias.addAlias('react', path.join(__dirname, './preact-compat.js'))
-  moduleAlias.addAlias('react-dom', 'preact-compat')
+  moduleAlias.addAlias('react', 'preact/compat')
+  moduleAlias.addAlias('react-dom', 'preact/compat')
 }

--- a/packages/next-preact/index.js
+++ b/packages/next-preact/index.js
@@ -1,5 +1,3 @@
-const path = require('path')
-
 module.exports = (nextConfig = {}) => {
   return Object.assign({}, nextConfig, {
     webpack(config, options) {
@@ -14,10 +12,10 @@ module.exports = (nextConfig = {}) => {
       }
 
       config.resolve.alias = Object.assign({}, config.resolve.alias, {
-        react$: path.join(__dirname, './preact-compat.js'),
-        'react-dom$': 'preact-compat',
-        react: path.join(__dirname, './preact-compat.js'),
-        'react-dom': 'preact-compat'
+        react$: 'preact/compat',
+        'react-dom$': 'preact/compat',
+        react: 'preact/compat',
+        'react-dom': 'preact/compat'
       })
 
       if (typeof nextConfig.webpack === 'function') {

--- a/packages/next-preact/package.json
+++ b/packages/next-preact/package.json
@@ -5,9 +5,7 @@
   "license": "MIT",
   "repository": "zeit/next-plugins",
   "peerDependencies": {
-    "preact": "^8.2.0",
-    "preact-compat": "^3.17.0",
-    "preact-context": "^1.1.3"
+    "preact": "^10.0.0-beta.3"
   },
   "dependencies": {
     "module-alias": "2.0.6"

--- a/packages/next-preact/preact-compat.js
+++ b/packages/next-preact/preact-compat.js
@@ -1,6 +1,0 @@
-const reactCompat = require('preact-compat')
-const createContext = require('preact-context')
-
-reactCompat.createContext = createContext.createContext
-
-module.exports = reactCompat

--- a/packages/next-preact/readme.md
+++ b/packages/next-preact/readme.md
@@ -5,13 +5,13 @@ Use [preact](https://preactjs.com/) with [Next.js](https://github.com/zeit/next.
 ## Installation
 
 ```
-npm install --save @zeit/next-preact preact preact-compat preact-context
+npm install --save @zeit/next-preact preact
 ```
 
 or
 
 ```
-yarn add @zeit/next-preact preact preact-compat preact-context
+yarn add @zeit/next-preact preact
 ```
 
 ## Usage
@@ -34,15 +34,12 @@ require('@zeit/next-preact/alias')()
 const { createServer } = require('http')
 const next = require('next')
 
-
 const app = next({ dev: process.env.NODE_ENV !== 'production' })
 const port = process.env.PORT || 3000
 const handle = app.getRequestHandler()
 
-app.prepare()
-.then(() => {
-  createServer(handle)
-  .listen(port, () => {
+app.prepare().then(() => {
+  createServer(handle).listen(port, () => {
     console.log(`> Ready on http://localhost:${port}`)
   })
 })


### PR DESCRIPTION
## Overview 

Preact X will be released in the near future and it'd be nice to be able to test it on next projects sooner rather than later. 

I haven't bumped the version (not sure how that process works), but I'll be happy to make whatever change I may need to. 

## Changes

- The `preact-compat` package now lives in `preact/compat` so no other packages are needed
- Preact v10 has native support for `createContext` so no `preact-context` package is needed
- Due to the above changes `preact-compat.js` isn't needed