### PR TITLE
feat(next-css): Support extra options for extract-css-chunks-webpack

### DIFF
--- a/packages/next-css/css-loader-config.js
+++ b/packages/next-css/css-loader-config.js
@@ -14,7 +14,8 @@ module.exports = (
     dev,
     isServer,
     postcssLoaderOptions = {},
-    loaders = []
+    loaders = [],
+    extractCssOptions = {}
   }
 ) => {
   // We have to keep a list of extensions for the splitchunk config
@@ -33,7 +34,7 @@ module.exports = (
 
   if (!isServer && !extractCssInitialized) {
     config.plugins.push(
-      new ExtractCssChunks({
+      new ExtractCssChunks(Object.assign({}, {
         // Options similar to the same options in webpackOptions.output
         // both options are optional
         filename: dev
@@ -43,7 +44,8 @@ module.exports = (
           ? 'static/chunks/[name].chunk.css'
           : 'static/chunks/[name].[contenthash:8].chunk.css',
         hot: dev
-      })
+      },
+      extractCssOptions))
     )
     extractCssInitialized = true
   }

--- a/packages/next-css/index.js
+++ b/packages/next-css/index.js
@@ -10,13 +10,14 @@ module.exports = (nextConfig = {}) => {
       }
 
       const { dev, isServer } = options
-      const { cssModules, cssLoaderOptions, postcssLoaderOptions } = nextConfig
+      const { cssModules, cssLoaderOptions, postcssLoaderOptions, extractCssOptions } = nextConfig
 
       options.defaultLoaders.css = cssLoaderConfig(config, {
         extensions: ['css'],
         cssModules,
         cssLoaderOptions,
         postcssLoaderOptions,
+        extractCssOptions,
         dev,
         isServer
       })

--- a/packages/next-css/package.json
+++ b/packages/next-css/package.json
@@ -6,7 +6,7 @@
   "repository": "zeit/next-plugins",
   "dependencies": {
     "css-loader": "^2.1.0",
-    "extract-css-chunks-webpack-plugin": "^3.3.2",
+    "extract-css-chunks-webpack-plugin": "^4.5.6",
     "find-up": "^3.0.0",
     "ignore-loader": "~0.1.2",
     "optimize-css-assets-webpack-plugin": "^5.0.1",

--- a/packages/next-css/readme.md
+++ b/packages/next-css/readme.md
@@ -178,7 +178,21 @@ module.exports = withCSS({
 })
 ```
 
+### With ExtractCssChunks options
 
+You can also pass a list of options to the `extract-css-chunks-webpack-plugin` by passing an object called `extractCssOptions`.
+
+For example, to ignore warning about CSS order, you can write :
+
+```js
+// next.config.js
+const withCSS = require('@zeit/next-css')
+module.exports = withCSS({
+  extractCssOptions: {
+    orderWarning: false
+  }
+})
+```
 
 ### Configuring Next.js
 

--- a/packages/next-sass/index.js
+++ b/packages/next-sass/index.js
@@ -14,7 +14,8 @@ module.exports = (nextConfig = {}) => {
         cssModules,
         cssLoaderOptions,
         postcssLoaderOptions,
-        sassLoaderOptions = {}
+        sassLoaderOptions = {},
+        extractCssOptions
       } = nextConfig
 
       options.defaultLoaders.sass = cssLoaderConfig(config, {
@@ -22,6 +23,7 @@ module.exports = (nextConfig = {}) => {
         cssModules,
         cssLoaderOptions,
         postcssLoaderOptions,
+        extractCssOptions,
         dev,
         isServer,
         loaders: [

--- a/packages/next-sass/readme.md
+++ b/packages/next-sass/readme.md
@@ -192,6 +192,21 @@ module.exports = withSass({
 })
 ```
 
+### With ExtractCssChunks options
+
+You can also pass a list of options to the `extract-css-chunks-webpack-plugin` by passing an object called `extractCssOptions`.
+
+For example, to ignore warning about CSS order, you can write :
+
+```js
+// next.config.js
+const withCSS = require('@zeit/next-css')
+module.exports = withCSS({
+  extractCssOptions: {
+    orderWarning: false
+  }
+})
+```
 
 ### Configuring Next.js
 


### PR DESCRIPTION
Hi there,
What's going on here : 
- [x] Updated extract-css-chunks-webpack-plugin to. v4.5.6 ;
- [x] Passed down `extractCssOptions` from `nextConfig` to the webpack plugin constructor;

What needs to be done :
- [x] Add something in next-css and next-sass `README.md`
- [ ] Arrange each package's version so they benefits from this upgrade (I don't know how you manage it here)

Happy to discuss !