### PR TITLE
Multiple nextjs prepare

### DIFF
--- a/packages/next-css/css-loader-config.js
+++ b/packages/next-css/css-loader-config.js
@@ -3,7 +3,6 @@ const findUp = require('find-up')
 const OptimizeCssAssetsWebpackPlugin = require('optimize-css-assets-webpack-plugin')
 
 const fileExtensions = new Set()
-let extractCssInitialized = false
 
 module.exports = (
   config,
@@ -31,7 +30,7 @@ module.exports = (
     }
   }
 
-  if (!isServer && !extractCssInitialized) {
+  if (!isServer) {
     config.plugins.push(
       new ExtractCssChunks({
         // Options similar to the same options in webpackOptions.output
@@ -45,7 +44,6 @@ module.exports = (
         hot: dev
       })
     )
-    extractCssInitialized = true
   }
 
   if (!dev) {


### PR DESCRIPTION
when I prepare more than one nextjs, I get "TypeError: this [MODULE_TYPE] is not a function" error, this problem is solved when I remove the extractCssInitialized value, I don't understand what it is, If it's unnecessary, would you accept?