### PR TITLE
fix(next-typescript): Missing peer dependency warning

### DIFF
--- a/packages/next-typescript/package.json
+++ b/packages/next-typescript/package.json
@@ -7,5 +7,8 @@
   "dependencies": {
     "@babel/preset-typescript": "^7.0.0"
   },
+  "peerDependencies": {
+    "@babel/core": "^7.0.0-0"
+  },
   "gitHead": "31e8978d07e5468f760a222a72d1e8f3f457e6ff"
 }


### PR DESCRIPTION
Fixes 
> ➤ YN0002: │ @zeit/next-typescript@npm:1.1.1 doesn't provide @babel/core@^7.0.0-0 requested by @babel/preset-typescript@npm:7.3.3

I know this package is obsolete for `next@9` but previous versions still require this plugin and with yarn pnp you actually get a runtime error
```bash
A package is trying to access a peer dependency that should be provided by its direct ancestor but isn't

Required package: @babel/core (via "@babel/core")
Required by: @babel/plugin-transform-typescript

[...]
(While processing: "/home/eps1lon/Development/src/js/material-ui/fork/.yarn/cache/@zeit-next-typescript-npm-1.1.1-c63d226a98.zip/node_modules/@zeit/next-typescript/babel.js$0")
```

Additional context: https://github.com/yarnpkg/berry/issues/3