### PR TITLE
Fix sass/scss sourcemaps

### DIFF
--- a/packages/next-sass/index.js
+++ b/packages/next-sass/index.js
@@ -14,7 +14,7 @@ module.exports = (nextConfig = {}) => {
         cssModules,
         cssLoaderOptions,
         postcssLoaderOptions,
-        sassLoaderOptions = {}
+        sassLoaderOptions = { sourceMap: dev }
       } = nextConfig
 
       options.defaultLoaders.sass = cssLoaderConfig(config, {


### PR DESCRIPTION
Currently, the sass/scss source maps are incorrect. The generated sourcemaps are created __after__ the sass sources have been compiled. This way, the sourcemaps in the build don't show the proper lines in the original .scss / .sass files.

By passing the `sourceMap` option to the sass loader, this should be fixed.