### PR TITLE
Make extensions customizable for less, sass, stylus

### DIFF
--- a/packages/next-less/index.js
+++ b/packages/next-less/index.js
@@ -14,11 +14,12 @@ module.exports = (nextConfig = {}) => {
         cssModules,
         cssLoaderOptions,
         postcssLoaderOptions,
+        extensions = ['less'],
         lessLoaderOptions = {}
       } = nextConfig
 
       options.defaultLoaders.less = cssLoaderConfig(config, {
-        extensions: ['less'],
+        extensions,
         cssModules,
         cssLoaderOptions,
         postcssLoaderOptions,
@@ -33,7 +34,7 @@ module.exports = (nextConfig = {}) => {
       })
 
       config.module.rules.push({
-        test: /\.less$/,
+        test: new RegExp(`\\.+(${[...extensions].join('|')})$`),
         use: options.defaultLoaders.less
       })
 

--- a/packages/next-sass/index.js
+++ b/packages/next-sass/index.js
@@ -14,11 +14,12 @@ module.exports = (nextConfig = {}) => {
         cssModules,
         cssLoaderOptions,
         postcssLoaderOptions,
+        extensions = ['scss', 'sass'],
         sassLoaderOptions = {}
       } = nextConfig
 
       options.defaultLoaders.sass = cssLoaderConfig(config, {
-        extensions: ['scss', 'sass'],
+        extensions,
         cssModules,
         cssLoaderOptions,
         postcssLoaderOptions,
@@ -32,16 +33,10 @@ module.exports = (nextConfig = {}) => {
         ]
       })
 
-      config.module.rules.push(
-        {
-          test: /\.scss$/,
-          use: options.defaultLoaders.sass
-        },
-        {
-          test: /\.sass$/,
-          use: options.defaultLoaders.sass
-        }
-      )
+      config.module.rules.push({
+        test: new RegExp(`\\.+(${[...extensions].join('|')})$`),
+        use: options.defaultLoaders.sass
+      })
 
       if (typeof nextConfig.webpack === 'function') {
         return nextConfig.webpack(config, options)

--- a/packages/next-stylus/index.js
+++ b/packages/next-stylus/index.js
@@ -14,11 +14,12 @@ module.exports = (nextConfig = {}) => {
         cssModules,
         cssLoaderOptions,
         postcssLoaderOptions,
+        extensions = ['styl'],
         stylusLoaderOptions = {}
       } = nextConfig
 
       options.defaultLoaders.stylus = cssLoaderConfig(config, {
-        extensions: ['styl'],
+        extensions,
         cssModules,
         cssLoaderOptions,
         postcssLoaderOptions,
@@ -33,7 +34,7 @@ module.exports = (nextConfig = {}) => {
       })
 
       config.module.rules.push({
-        test: /\.styl$/,
+        test: new RegExp(`\\.+(${[...extensions].join('|')})$`),
         use: options.defaultLoaders.stylus
       })
 


### PR DESCRIPTION
Allow overriding extensions.

Motivation:
`extensions: ['css', 'less']` solves https://github.com/zeit/next-plugins/issues/608. `withLess` doesn't seem to work well together with `withCSS`, so I just set it up to treat CSS like LESS equally.