### PR TITLE
Add next-plugin-profiler to list of community plugins

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -32,6 +32,7 @@
 - [next-fonts](https://github.com/rohanray/next-fonts)
 - [next-react-svg](https://github.com/jeremybarbet/next-react-svg)
 - [next-plugin-yaml](https://github.com/tomasz-sodzawiczny/next-plugin-yaml)
+- [next-plugin-profiler](https://github.com/taylorbryant/next-plugin-profiler)
 
 ## Publishing
 


### PR DESCRIPTION
This PR adds `next-plugin-profiler`, a plugin that allows you to enable the React profiler, to the list of community plugins. 