### PR TITLE
update: less dependencies 

### DIFF
--- a/packages/next-less/package.json
+++ b/packages/next-less/package.json
@@ -6,13 +6,13 @@
   "repository": "zeit/next-plugins",
   "dependencies": {
     "@zeit/next-css": "0.2.1-canary.4",
-    "less-loader": "4.1.0"
+    "less-loader": "6.2.0"
   },
   "devDependencies": {
-    "less": "^2.7.3"
+    "less": "^3.12.0"
   },
   "peerDependencies": {
-    "less": "^2.7.3"
+    "less": "^3.12.0"
   },
   "gitHead": "31e8978d07e5468f760a222a72d1e8f3f457e6ff"
 }


### PR DESCRIPTION
There are some errors in case we use new `less` libraries since there are some syntax that only supported on latest version such as `each` which has been added since version [v3.7.0](https://github.com/less/less.js/blob/master/CHANGELOG.md#v370-2018-07-11)
Hopefully, this will avoid compile fail for new version `less` libraries.  

there is also a workaround if this PR not accepted
adding below code in `package.json` solved my issue:
 ` "resolutions": {
    "less": "^3.10.3",
    "less-loader": "^5.0.0"
  }`